### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cosmicds/vue-toolkit",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "browser": "dist/index.umd.js",
   "dependencies": {
     "@capacitor/core": "^5.7.4",


### PR DESCRIPTION
The next version will be 0.3.0, so this PR bumps the package version in the `package.json`.