### PR TITLE
Add documentation to composables and utility functions

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -1,7 +1,7 @@
-name: Build
+name: Build and Deploy Docs
 
 on:
-  pull_request_target:
+  push:
     branches:
       main
 
@@ -36,4 +36,11 @@ jobs:
 
       - name: Build docs
         run: yarn docs
+
+      - name: Deploy docs to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        if: ${{ steps.draft.outputs.value }} == 'true'
+        with:
+          branch: gh-pages
+          folder: docs 
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ tsconfig.tsbuildinfo
 **/tests_output/**
 
 *.env
+
+docs/

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "eslint-plugin-vue": "^9.8.0",
     "less": "^4.2.0",
     "less-loader": "^12.1.0",
+    "typedoc": "^0.25.13",
     "typescript": "^4.9.4",
     "vue-template-compiler": "^2.7.14",
     "webpack": "^5.75.0"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "scripts": {
     "build": "vue-cli-service build --target lib --name index src/index.ts",
     "clean": "rimraf dist",
+    "docs": "typedoc",
     "lint": "vue-cli-service lint src --no-fix"
   },
   "types": "./dist/src/index.d.ts"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "less": "^4.2.0",
     "less-loader": "^12.1.0",
     "typedoc": "^0.25.13",
+    "typedoc-plugin-vue": "^1.1.0",
     "typescript": "^4.9.4",
     "vue-template-compiler": "^2.7.14",
     "webpack": "^5.75.0"

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,13 +1,10 @@
 /** Class representing a background imageset for WorldWide Telescope */
 export class BackgroundImageset {
+  /** The outward-facing name to use for the imageset in a story */
   public imagesetName: string;
+  /** The name of the imageset object inside WorldWide Telescope */
   public displayName: string;
 
-  /**
-    * Create a background imageset
-    * @param{string} displayName - The outward-facing name to use for the imageset
-    * @param{string} imagesetName - The name of the imageset object inside WorldWideTelescope
-    */
   constructor(displayName: string, imagesetName: string) {
     this.displayName = displayName;
     this.imagesetName = imagesetName;

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,13 +1,20 @@
+/** Class representing a background imageset for WorldWide Telescope */
 export class BackgroundImageset {
   public imagesetName: string;
   public displayName: string;
 
+  /**
+    * Create a background imageset
+    * @param{string} displayName - The outward-facing name to use for the imageset
+    * @param{string} imagesetName - The name of the imageset object inside WorldWideTelescope
+    */
   constructor(displayName: string, imagesetName: string) {
     this.displayName = displayName;
     this.imagesetName = imagesetName;
   }
 }
 
+/** A default list of `BackgroundImagset` objects to use within data stories */
 export const skyBackgroundImagesets: BackgroundImageset[] = [
   new BackgroundImageset(
     "Optical (Terapixel DSS)",

--- a/src/components/CreditLogos.vue
+++ b/src/components/CreditLogos.vue
@@ -23,7 +23,6 @@ import { computed } from "vue";
 import { CreditLogosProps } from "../types";
 
 const props = withDefaults(defineProps<CreditLogosProps>(), {
-  visible: true,
   logoSize: "5vmin"
 });
 

--- a/src/components/GeolocationButton.vue
+++ b/src/components/GeolocationButton.vue
@@ -59,7 +59,6 @@ import { GeolocationButtonProps } from "../types";
 
 const props = withDefaults(defineProps<GeolocationButtonProps>(), {
   color: "white",
-  disabled: false,
   size: "small",
   density: "comfortable",
   elevation: "2",
@@ -73,7 +72,6 @@ const props = withDefaults(defineProps<GeolocationButtonProps>(), {
   label: "My Location",
   trueIcon: "mdi-crosshairs-gps",
   falseIcon: "mdi-crosshairs",
-  backgroundColor: "black",
   showPermissions: false,
 });
 

--- a/src/composables.ts
+++ b/src/composables.ts
@@ -1,6 +1,10 @@
 import { ref, onMounted, onUnmounted, Ref } from "vue";
 import screenfull from "screenfull";
 
+/**
+  * A composable that encapsulates fullscreen behavior.
+  * @returns {Ref<boolean>} A reactive variable indicating whether or not fullscreen mode is active
+  */ 
 export function useFullscreen(): Ref<boolean> {
   const fullscreenModeActive = ref(false);
   function update(_event: Event) {
@@ -22,11 +26,20 @@ export function useFullscreen(): Ref<boolean> {
   return fullscreenModeActive;
 }
 
+/** Interface describing the shape of a browser window */
 export interface WindowShape {
   width: number;
   height: number;
 }
+
+/** A default `WindowShape` to use */
 export const defaultWindowShape = { width: 1200, height: 900 };
+
+/**
+  * A composable that encapsulates a changing window shape.
+  *
+  * @returns {WindowShape} A reactive variable describing the current window shape.
+  */
 export function useWindowShape() {
   const windowShape = ref<WindowShape>(defaultWindowShape);
   const resizeObserver = new ResizeObserver(_entries => update());
@@ -51,6 +64,6 @@ export function useWindowShape() {
     resizeObserver.unobserve(document.body);
   });
 
-  return { windowShape, resizeObserver };
+  return windowShape;
 }
 

--- a/src/composables.ts
+++ b/src/composables.ts
@@ -3,7 +3,7 @@ import screenfull from "screenfull";
 
 /**
   * A composable that encapsulates fullscreen behavior.
-  * @returns {Ref<boolean>} A reactive variable indicating whether or not fullscreen mode is active
+  * @returns A reactive variable indicating whether or not fullscreen mode is active
   */ 
 export function useFullscreen(): Ref<boolean> {
   const fullscreenModeActive = ref(false);
@@ -38,7 +38,7 @@ export const defaultWindowShape = { width: 1200, height: 900 };
 /**
   * A composable that encapsulates a changing window shape.
   *
-  * @returns {WindowShape} A reactive variable describing the current window shape.
+  * @returns A reactive variable describing the current window shape.
   */
 export function useWindowShape() {
   const windowShape = ref<WindowShape>(defaultWindowShape);

--- a/src/geolocation.ts
+++ b/src/geolocation.ts
@@ -5,7 +5,7 @@ import { Geolocation, PermissionStatus as CapacitorPermissionStatus, Position, P
 /**
   * Determine which of two capacitor permission states is 'better'.
   * This implementation takes "prompt-with-rationale" to be better than "prompt".
-  * @returns {CapacitorPermissionState} The 'better' of the two input permission states
+  * @returns The 'better' of the two input permission states
   */
 function betterPermissionState(firstState: CapacitorPermissionState, secondState: CapacitorPermissionState): CapacitorPermissionState {
   const states: CapacitorPermissionState[] = ["granted", "prompt-with-rationale", "prompt", "denied"];
@@ -22,14 +22,8 @@ export type PositionCoords = Position['coords'];
 /**
   * A composable that encapsulates the current state of the browser
   * geolocation position and permission status.
-  * @param {boolean} onStartup - Whether or not to query the user's geolocation on startup.
-  * @returns {{
-  *   geolocation: Ref<PositionCoords | null>,
-  *   error: Ref<GeolocationPositionError | null>,
-  *   permissions: Ref<string>,
-  *   permissionGranted: Ref<boolean>,
-  *   hasPermissionsAPI: Ref<boolean>
-  * }}
+  * @param onStartup - Whether or not to query the user's geolocation on startup.
+  * @returns Reactive state describing the geolocation
   */
 export function useGeolocation(onStartup=true) {
 

--- a/src/geolocation.ts
+++ b/src/geolocation.ts
@@ -2,6 +2,11 @@ import { ref, onMounted } from "vue";
 import { Capacitor, PermissionState as CapacitorPermissionState } from '@capacitor/core';
 import { Geolocation, PermissionStatus as CapacitorPermissionStatus, Position, PositionOptions } from "@capacitor/geolocation";
 
+/**
+  * Determine which of two capacitor permission states is 'better'.
+  * This implementation takes "prompt-with-rationale" to be better than "prompt".
+  * @returns {CapacitorPermissionState} The 'better' of the two input permission states
+  */
 function betterPermissionState(firstState: CapacitorPermissionState, secondState: CapacitorPermissionState): CapacitorPermissionState {
   const states: CapacitorPermissionState[] = ["granted", "prompt-with-rationale", "prompt", "denied"];
   for (const state of states) {
@@ -13,6 +18,19 @@ function betterPermissionState(firstState: CapacitorPermissionState, secondState
 }
 
 export type PositionCoords = Position['coords'];
+
+/**
+  * A composable that encapsulates the current state of the browser
+  * geolocation position and permission status.
+  * @param {boolean} onStartup - Whether or not to query the user's geolocation on startup.
+  * @returns {{
+  *   geolocation: Ref<PositionCoords | null>,
+  *   error: Ref<GeolocationPositionError | null>,
+  *   permissions: Ref<string>,
+  *   permissionGranted: Ref<boolean>,
+  *   hasPermissionsAPI: Ref<boolean>
+  * }}
+  */
 export function useGeolocation(onStartup=true) {
 
   const geolocation = ref<PositionCoords | null>(null);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { BackgroundImageset, skyBackgroundImagesets } from "./background";
 import { useFullscreen, useWindowShape, WindowShape } from "./composables";
 import { PositionCoords, useGeolocation } from "./geolocation";
-import { KeyboardControlSettings } from "./keyboard";
+import { KeyPressInfo, KeyboardControlSettings } from "./keyboard";
 import { useWWTKeyboardControls } from "./wwt-utils";
 
 import IconButton from "./components/IconButton.vue";
@@ -15,6 +15,7 @@ import Gallery from "./components/Gallery.vue";
 
 export {
   BackgroundImageset,
+  KeyPressInfo,
   KeyboardControlSettings,
   Gallery,
   IconButton,

--- a/src/keyboard.ts
+++ b/src/keyboard.ts
@@ -1,15 +1,20 @@
 /** Class representing a key press */
-class KeyPressInfo {
+export class KeyPressInfo {
+  /** The code of the key that was pressed */
   code: string;
+  /** Whether the control modifier was pressed */
   ctrl: boolean;
+  /** Whether the alt modifier was pressed */
   alt: boolean;
+  /** Whether the shift modifier was pressed */
   shift: boolean;
+  /** Whether the meta modifier was pressed */
   meta: boolean;
 
   /**
     * Create an instance of key press information
-    * @param code - The key code describing the keypress
-    * @param An object of boolean values describing which modifier keys were pressed down
+    * @param code The key code describing the keypress
+    * @param modifiers An object of boolean values describing which modifier keys were pressed down
     */
   constructor(
     code: string,

--- a/src/keyboard.ts
+++ b/src/keyboard.ts
@@ -8,8 +8,8 @@ class KeyPressInfo {
 
   /**
     * Create an instance of key press information
-    * @param{string} code - The key code describing the keypress
-    * @param{{ ctrl: boolean?, alt: boolean?, shift: boolean?, meta: boolean? }} - An object of boolean values describing which modifier keys were pressed down
+    * @param code - The key code describing the keypress
+    * @param An object of boolean values describing which modifier keys were pressed down
     */
   constructor(
     code: string,
@@ -29,8 +29,8 @@ class KeyPressInfo {
 
   /**
     * Determine whether a keyboard event matches this key press information
-    * @param{KeyboardEvent} event - The keyboard event to test
-    * @returns{boolean} Whether or not the given event matches
+    * @param event - The keyboard event to test
+    * @returns Whether or not the given event matches
     */
   matches(event: KeyboardEvent): boolean {
     return (
@@ -94,9 +94,9 @@ export class KeyboardControlSettings {
   ] as const;
   
   /** Make a listener for a given WWT action
-    * @param{ActionType} actionName - The WWT action to make a listener for
-    * @param{() => void} action - Function to execute when the given WWT action occurs
-    * @returns{(event: KeyboardEvent) => void} The key event listener for the desired behavior 
+    * @param actionName - The WWT action to make a listener for
+    * @param action - Function to execute when the given WWT action occurs
+    * @returns The key event listener for the desired behavior 
     */
   makeListener(
     actionName: ActionType,

--- a/src/keyboard.ts
+++ b/src/keyboard.ts
@@ -1,3 +1,4 @@
+/** Class representing a key press */
 class KeyPressInfo {
   code: string;
   ctrl: boolean;
@@ -5,6 +6,11 @@ class KeyPressInfo {
   shift: boolean;
   meta: boolean;
 
+  /**
+    * Create an instance of key press information
+    * @param{string} code - The key code describing the keypress
+    * @param{{ ctrl: boolean?, alt: boolean?, shift: boolean?, meta: boolean? }} - An object of boolean values describing which modifier keys were pressed down
+    */
   constructor(
     code: string,
     modifiers?: {
@@ -21,6 +27,11 @@ class KeyPressInfo {
     this.meta = modifiers?.meta ?? false;
   }
 
+  /**
+    * Determine whether a keyboard event matches this key press information
+    * @param{KeyboardEvent} event - The keyboard event to test
+    * @returns{boolean} Whether or not the given event matches
+    */
   matches(event: KeyboardEvent): boolean {
     return (
       event.code === this.code &&
@@ -32,6 +43,12 @@ class KeyPressInfo {
   }
 }
 
+/** Type describing the possible WWT actions */
+type ActionType = KeyboardControlSettings["actionTypes"][number];
+
+/**
+  * Class describing keyboard control settings for WorldWide Telescope actions
+  */
 export class KeyboardControlSettings {
   zoomIn: KeyPressInfo[];
   zoomOut: KeyPressInfo[];
@@ -41,6 +58,15 @@ export class KeyboardControlSettings {
   moveRight: KeyPressInfo[];
   moveAmount: number;
 
+  /**
+    * Create a new set of keyboard control settings
+    * @param{KeyPressInfo[]} zoomIn - a list describing which key press(es) should result in zooming in
+    * @param{KeyPressInfo[]} zoomOut - a list describing which key press(es) should result in zooming out 
+    * @param{KeyPressInfo[]} moveUp - a list describing which key press(es) should result in moving the view up
+    * @param{KeyPressInfo[]} moveLeft - a list describing which key press(es) should result in moving the view left 
+    * @param{KeyPressInfo[]} moveDown - a list describing which key press(es) should result in moving the view down 
+    * @param{KeyPressInfo[]} moveRight - a list describing which key press(es) should result in moving the view right 
+    */
   constructor({
     zoomIn = [new KeyPressInfo("KeyI")],
     zoomOut = [new KeyPressInfo("KeyO")],
@@ -69,8 +95,13 @@ export class KeyboardControlSettings {
     "moveRight",
   ] as const;
   
+  /** Make a listener for a given WWT action
+    * @param{ActionType} actionName - The WWT action to make a listener for
+    * @param{() => void} action - Function to execute when the given WWT action occurs
+    * @returns{(event: KeyboardEvent) => void} The key event listener for the desired behavior 
+    */
   makeListener(
-    actionName: KeyboardControlSettings["actionTypes"][number],
+    actionName: ActionType,
     action: () => void
   ): (event: KeyboardEvent) => void {
     return (event) => {

--- a/src/keyboard.ts
+++ b/src/keyboard.ts
@@ -50,23 +50,21 @@ type ActionType = KeyboardControlSettings["actionTypes"][number];
   * Class describing keyboard control settings for WorldWide Telescope actions
   */
 export class KeyboardControlSettings {
+  /** A list of key presses that should result in zooming in */
   zoomIn: KeyPressInfo[];
+  /** A list of key presses that should result in zooming out */
   zoomOut: KeyPressInfo[];
+  /** A list of key presses that should result in moving the view up */
   moveUp: KeyPressInfo[];
+  /** A list of key presses that should result in moving the view down */
   moveDown: KeyPressInfo[];
+  /** A list of key presses that should result in moving the view left */
   moveLeft: KeyPressInfo[];
+  /** A list of key presses that should result in moving the view right */
   moveRight: KeyPressInfo[];
+  /** A value describing how much to move on a movement press. Larger means more movement. */
   moveAmount: number;
 
-  /**
-    * Create a new set of keyboard control settings
-    * @param{KeyPressInfo[]} zoomIn - a list describing which key press(es) should result in zooming in
-    * @param{KeyPressInfo[]} zoomOut - a list describing which key press(es) should result in zooming out 
-    * @param{KeyPressInfo[]} moveUp - a list describing which key press(es) should result in moving the view up
-    * @param{KeyPressInfo[]} moveLeft - a list describing which key press(es) should result in moving the view left 
-    * @param{KeyPressInfo[]} moveDown - a list describing which key press(es) should result in moving the view down 
-    * @param{KeyPressInfo[]} moveRight - a list describing which key press(es) should result in moving the view right 
-    */
   constructor({
     zoomIn = [new KeyPressInfo("KeyI")],
     zoomOut = [new KeyPressInfo("KeyO")],

--- a/src/mapbox.ts
+++ b/src/mapbox.ts
@@ -22,44 +22,65 @@ export interface MapBoxFeature {
   context: MapBoxContextItem[];
 }
 
+/** Interface describing a MapBox feature collection, which is a GeoJSON object */
 export interface MapBoxFeatureCollection {
+  /* The type of the collection */
   type: "FeatureCollection";
+  /** The list of features in the collection */
   features: MapBoxFeature[];
 }
 
+/** Union type describing the feature types available in MapBox */
 export type MapBoxFeatureType = "country" | "region" | "postcode" | "district" | "place" | "locality" | "neighborhood" | "street" | "address";
+
+/** Union type describing the worldviews available in MapBox */
 export type MapBoxWorldviewType = "ar" | "cn" | "in" | "jp" | "ma" | "ru" | "tr" | "us";
 
-// For countries, use the ISO 3166-1 alpha-2 country codes:
-// https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+/** Interface describing options common to both forward and reverse MapBox geocoding */
 interface BaseMapBoxGeocodingOptions {
-  permanent?: boolean;
+  /** The language to use for the results, as an IEFT language tag */
   language?: string;
+  /** The number of results to return. Default is 5 */
   limit?: number;
+  /** Countries to include in the results. If a list is given, any result outside of these countries is omitted
+    * Specify countries using ISO 3166-1 alpha-2 country codes: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+    */
   countries?: string[];
+  /** The result types to include */
   types?: MapBoxFeatureType[];
 
-  // MapBox API access token
+  /** The access token for MapBox. Required */
   // eslint-disable-next-line @typescript-eslint/naming-convention
   access_token: string;
 }
 
+/** Interface describing options for forward geocoding */
 interface MapBoxForwardGeocodingOptions extends BaseMapBoxGeocodingOptions {
+  /** Whether to return autocomplete results. MapBox default is true */
   autocomplete?: boolean;
-  bbox?: number;
-  format?: "geojson" | "v5";
+  /** A bounding box for results. Should be a string of the form "minLon,minLat,maxLon,maxLat" */
+  bbox?: string;
+  /** Whether MapBox should try approximate, as well as exact, matching. MapBox default is true */
+  fuzzyMatch?: boolean;
+  /** If specified, results are biased to favor results closer to this location. Should be a string of the form "longitude, latitude" */
   proximity?: string;
 }
 
+/** Interface describing options for reverse geocoding */
 interface MapBoxReverseGeocodingOptions extends BaseMapBoxGeocodingOptions {
+  /** The worldview to use for search results. MapBox default is "us" */
   worldview?: MapBoxWorldviewType[];
 }
 
+/** Interface describing geocoding query parameters that are adjusted from the options exposed by our methods */
 interface MapBoxAdjustedGeocodingParams {
-  countries?: string;
+  /** We take in a string of country codes, but MapBox wants a comma-separated list */
+  country?: string;
+  /** We take in a list of types, but MapBox wants a comma-separated list */
   types?: string;
  }
 
+/** A type describing the query parameter type corresponding to one of our option types */
 type MapBoxQueryOptions<T extends BaseMapBoxGeocodingOptions> = {
   [K in keyof Omit<T, "countries" | "types">]: T[K];
 } & MapBoxAdjustedGeocodingParams;
@@ -68,6 +89,12 @@ const DEFAULT_RELEVANT_FEATURE_TYPES = ["postcode", "place", "region", "country"
 const NA_COUNTRIES = ["United States", "Canada", "Mexico"];
 const NA_ABBREVIATIONS = ["US-", "CA-", "MX-"];
 
+/** Find the best feature from a collection of MapBox features.
+  * We look for feature place types in the order: 'place', 'postcode', 'region', 'country'
+  * @param collection The collection of items to search
+  * @param relevantTypes The set of feature place types to consider. If not specified, we use the four types mentioned above
+  * @returns The "best" feature, as described above
+  */
 export function findBestFeature(collection: MapBoxFeatureCollection, relevantTypes?: MapBoxFeatureType[]): MapBoxFeature | null {
   const types = relevantTypes ?? DEFAULT_RELEVANT_FEATURE_TYPES;
   const relevantFeatures = collection.features.filter(feature => types.some(type => feature.place_type.includes(type)));
@@ -86,6 +113,12 @@ export function findBestFeature(collection: MapBoxFeatureCollection, relevantTyp
   return null;
 }
 
+/**
+  * Create text describing a MapBox feature, based on the MapBox items inside of the feature's context
+  * @param feature The MapBox feature
+  * @param relevantTypes The item types inside the feature's context that we want to consider when creating the string. If not specified, we use 'place', 'postcode', 'region', and 'country'
+  * @returns A string describing the feature
+  */
 export function textForMapboxFeature(feature: MapBoxFeature, relevantTypes?: MapBoxFeatureType[]): string {
   const types = relevantTypes ?? DEFAULT_RELEVANT_FEATURE_TYPES;
   const pieces: string[] = [];
@@ -116,21 +149,38 @@ export function textForMapboxFeature(feature: MapBoxFeature, relevantTypes?: Map
   return pieces.join(", ");
 }
 
+/**
+  * Return text describing the "best" feature in a MapBox collection.
+  * See @link{findBestFeature} for a description of how a feature is chosen
+  * @param results The feature collection to use
+  * @param relevantTypes The item types inside the best feature's context that we want to consider when creating the string. If not specified, we use 'place', 'postcode', 'region', and 'country'
+  */
 export function textForMapboxResults(results: MapBoxFeatureCollection, relevantTypes?: MapBoxFeatureType[]): string {
   const feature = findBestFeature(results, relevantTypes);
   return feature !== null ? textForMapboxFeature(feature) : "";
 }
 
+/**
+  * Convert our MapBox options to options suitable for a query to the MapBox API
+  * @param options The toolkit MapBox options
+  * @returns The options converted into a suitable object to use for a MapBox API query
+  * @template T extends @link{BaseMapBoxGeocodingOptions}
+  */
 function convertOptionsToQueryParams<T extends BaseMapBoxGeocodingOptions>(options: T): MapBoxQueryOptions<T> {
   const { types, countries, ...params } = options;
   const queryParams = params as MapBoxQueryOptions<T>;
   queryParams.types = (types ?? ["place", "postcode"]).join(",");
   if (countries) {
-    queryParams.countries = countries.join(",");
+    queryParams.country = countries.join(",");
   }
   return queryParams;
 }
 
+/**
+  * Convert a set of MapBox geocoding options to URL search parameters
+  * @param options The MapBox geocoding options
+  * @returns A `URLSearchParams` object that can be used for a MapBox query
+  */
 function searchParams(options: MapBoxForwardGeocodingOptions | MapBoxReverseGeocodingOptions): URLSearchParams {
   const search = new URLSearchParams();
   const queryParams = convertOptionsToQueryParams(options);
@@ -138,6 +188,13 @@ function searchParams(options: MapBoxForwardGeocodingOptions | MapBoxReverseGeoc
   return search;
 }
 
+/**
+  * Obtain text describing a given longitude and latitude based on a MapBox reverse geocoding query
+  * @param longitudeDeg The longitude of the location, in degrees
+  * @param latitudeDeg The latitude of the location, in degrees
+  * @param options Options for the MapBox reverse geocoding
+  * @returns A promise that resolves to the string describing the given coordinates
+  */
 export async function textForLocation(longitudeDeg: number, latitudeDeg: number, options: MapBoxReverseGeocodingOptions): Promise<string> {
   const search = searchParams(options);
   const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${longitudeDeg},${latitudeDeg}.json?${search.toString()}`;
@@ -155,6 +212,14 @@ export async function textForLocation(longitudeDeg: number, latitudeDeg: number,
     });
 }
 
+/**
+  * Obtain a collection of MapBox items obtained from performing a forward geocoding query for a particular search string.
+  * Note that the number of items returned is set by the `limit` field in your options.
+  * If `limit` is not specified, the MapBox default is 5
+  * @param searchText The search string
+  * @param options Options for the MapBox forward geocoding
+  * @returns A promise that resolves to the found collection of MapBox items
+  */
 export async function geocodingInfoForSearch(searchText: string, options: MapBoxForwardGeocodingOptions): Promise<MapBoxFeatureCollection> {
   const search = searchParams(options);
   const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${searchText}.json?${search.toString()}`;

--- a/src/mapbox.ts
+++ b/src/mapbox.ts
@@ -1,3 +1,4 @@
+/** Interface describing a MapBox content item */
 export interface MapBoxContextItem {
   id: string;
   // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,23 +106,41 @@ export type SizeType = Extract<FontAwesomeIconProps, 'size'>;
 
 /** An interface describing props for the icon button */
 export interface IconButtonProps {
+  /** Whether or not the icon button is active. Only makes sense in cases where one wants the button to have an on/off state */
   modelValue?: boolean;
+  /** The name of the FontAwesome icon to use. It's assumed that only one of this and `mdIcon` will be used */
   faIcon?: string;
+  /** The name of the MID icon to use. It's assumed that only one of this and `faIcon` will be used */
   mdIcon?: string;
+  /** The primary color of the button. Sets the icon and border colors. Default is white */
   color?: string;
+  /** The color of the button when focused. Default is white */
   focusColor?: string;
+  /** The background color of the button. Default is #040404 */
   backgroundColor?: string;
+  /** Whether to use a box shadow when the button is active. Default is true */
   boxShadow?: boolean;
+  /** Whether the button has a border. Default is true */
   border?: boolean;
+  /** The time duration, in ms, to recognize a press event as a long press. Default is 500 */
   longPressTimeMs?: number;
+  /** The tooltip text for the button. If not specified, tooltip will not be shown */
   tooltipText?: string;
+  /** The location of the tooltip. Default is start */
   tooltipLocation?: string;
+  /** Whether to show the tooltip when the button is clicked. Default is false */
   tooltipOnClick?: boolean;
+  /** Whether to show the tooltip when the button is focused. Default is false */
   tooltipOnFocus?: boolean;
+  /** Whether to show the tooltip when the button is hovered. Default is true */
   tooltipOnHover?: boolean;
+  /** The distance away from the button that the tooltip appears. Default is 0 */
   tooltipOffset?: string | number;
+  /** Whether to show the tooltip when appropriate. Default is true */
   showTooltip?: boolean;
+  /** The size of the FontAwesome icon */
   faSize?: SizeType;
+  /** The size of the MDI icon. Should be a valid CSS size */
   mdSize?: string;
 }
 
@@ -149,51 +167,88 @@ export interface LeafletMapOptions extends TileLayerOptions {
 
 /** An interface describing a GeoJSON item, to be used as a prop for the location selector */
 export interface GeoJSONProp {
+  /** The URL of a remote GeoJSON resource. This and `geojson` and not intended to be used together */
   url?: string;
+  /** A GeoJSON object to add to the location selector */
   geojson?: GeoJSON.FeatureCollection | GeoJSON.Feature | GeoJSON.GeometryCollection;
+  /** The style options for any circle markers related to this item. Required */
   style: CircleMarkerOptions;
 }
 
+/** Interface describing a place on the location selector */
 export interface PlaceDeg extends LocationDeg { 
+  /** The color to use for the circle showing the place */
   color?: string;
+  /** The fill color to use for the circle showing the place */
   fillColor?: string;
+  /** The fill opacity to use for the circle showing the place */
   fillOpacity?: number;
+  /** The radius to use for the circle showing the place */
   radius?: number;
+  /** The name of the place */
   name?: string;
 }
 
+/** Interface describing props for the location selector */
 export interface LocationSelectorProps {
+  /** The color to use for the activator button */
   activatorColor?: string;
+  /** Whether to attempt to detect the user's location when the component is mounted. Default is true */
   detectLocation?: boolean;
+  /** The currently selected location. Default is the coordinates for Harvard College Observatory */
   modelValue?: LocationDeg;
+  /** Map options for the Leaflet map. If not specified, sensible defaults are used */
   mapOptions?: LeafletMapOptions;
+  /** The initial place to be selected on the map */
   initialPlace?: PlaceDeg;
+  /** The list of places to show on the map */
   places?: PlaceDeg[];
+  /** Options for place circles */
   placeCircleOptions?: CircleMarkerOptions;
+  /** Whether places can be selected on the map. Default is true */
   placeSelectable?: boolean;
+  /** Whether a location can be selected on the map. Default is true */
   selectable?: boolean;
+  /** Options for the circle showing the selected place */
   selectedCircleOptions?: CircleMarkerOptions;
+  /** Which event to use to select a location. Default is "click" */
   selectionEvent?: "click" | "dblclick";
+  /** Whether to use world radii for circle sizes (as opposed to screen radii). Default is true */
   worldRadii?: boolean;
+  /** GeoJSON items to display on the map. The list is empty by default */
   geoJsonFiles?: GeoJSONProp[];
+  /** Layers to show on the map. The list is empty by default */
   layers?: L.Layer[];
 }
 
 /* WWT HUD */
 
+/** Interface describing the location of the WWT HUD */
 export interface HUDLocation {
+  /** Distance from the top. Should be a valid CSS value */
   top?: string | number,
+  /** Distance from the left. Should be a valid CSS value */
   left?: string | number,
+  /** Distance from the bottom. Should be a valid CSS value */
   bottom?: string | number,
+  /** Distance from the right. Should be a valid CSS value */
   right?: string | number,
 }
 
+/** Interface describing props for the WWT HUD */
 export interface WwtHUDProps {
+  /** Location of the HUD in the browser window. Default is `{ top: "50%", left: "50%" }` */
   location?: HUDLocation;
+  /** Define an offset for the HUD. Default is `{ x: 0.5, y: 0.5 }` */
   offsetCenter?: { x: number; y: number };
+  /** Other variables to include in the HUD display. Default is `{}` */
   otherVariables?: Object;  // eslint-disable-line @typescript-eslint/ban-types
+  /** The font size of the HUD text. Should be a valid CSS value for `font-size` */
   fontSize?: string;
+  /** Background color for the HUD. Should be a valid CSS color. Default is `rgba(0, 0, 0, 0.5)` */
   backgroundColor?: string | null;
+  /** Text shadow for the HUD text. Should be a valid CSS value for `text-shadow`. Default is `"0 0 5px black"` */
   textShadow?: string | null;
+  /** The WWT engine store to use for the HUD. Required */
   store: ReturnType<typeof engineStore>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,35 +55,56 @@ export interface GalleryProps {
 
 /* Geolocation button */
 
+/** A union type consisting of the density options for the geolocation button */
 export type GeolocationButtonDensity = null | "default" | "comfortable" | "compact";
 
 /** Interface describing props for the geolocation button */
 export interface GeolocationButtonProps {
+  /** The color of the geolocation button. Defaults to "white" */
   color?: string;
-  disabled?: boolean;
+  /** The size of the button */
   size?: string;
+  /** The density of the button. This adjusts the vertical height of the button. Defaults to "comfortable" */
   density?: GeolocationButtonDensity;
+  /** The elevation of the button. Defaults to "2" */
   elevation?: string;
+  /** Whether to hide the button. Defaults to false */
   hideButton?: boolean;
+  /** Whether to show the button's text label. Defaults to false */
   showTextLabel?: boolean;
+  /** Whether to show the button's geolocation coordinates. Defaults to false */ 
   showCoords?: boolean;
+  /** Whether to show text indicating when location fetching is in progress. Defaults to false */
   showTextProgress?: boolean;
+  /** Whether to show circle indicator when fetching is in progress. Defaults to true */
   showProgressCircle?: boolean;
+  /** Whether to include text on the button. Defaults to false */
   useTextButton?: boolean;
+  /** The size of the in-progress circle. Defaults to 12 */
   progressCircleSize?: number;
+  /** The button's label. Defaults to "My Location" */
   label?: string;
+  /** The ID to use to create the button ID */
   id?: string;
+  /** The icon to use when the geolocation has been obtained */
   trueIcon?: string;
+  /** The icon to use when there is no value for the geolocation */
   falseIcon?: string;
-  backgroundColor?: string;
+  /** Whether to show the location and permission status. Useful for debugging, defaults to false */
   showPermissions?: boolean;
 }
 
 /* Icon button */
-// We need to do this because FontAwesome doesn't export the prop types
+
+/**
+  * A type describing the props of a FontAwesome icon
+  * We need to do this because FontAwesome doesn't export the prop types
+  */ 
 export type FontAwesomeIconProps = InstanceType<typeof FontAwesomeIcon>["$props"];
+/** A type describing the size options for a FontAwesome icon */
 export type SizeType = Extract<FontAwesomeIconProps, 'size'>;
 
+/** An interface describing props for the icon button */
 export interface IconButtonProps {
   modelValue?: boolean;
   faIcon?: string;
@@ -108,17 +129,25 @@ export interface IconButtonProps {
 
 /* Location selector */
 
+/** An interface describing a latitude/longitude location */
 export interface LocationDeg {
+  /** The longitude of the location, in degrees */
   longitudeDeg: number;
+  /** The latitude of the location, in degrees */
   latitudeDeg: number;
 }
 
+/** An interface describing options for the Leaflet map in the location selector */
 export interface LeafletMapOptions extends TileLayerOptions {
+  /** The template URL to use for the base map layer */
   templateUrl: string;
+  /** The initial location to center the map on */
   initialLocation?: LocationDeg;
+  /** The initial zoom level of the map */
   initialZoom?: number;
 }
 
+/** An interface describing a GeoJSON item, to be used as a prop for the location selector */
 export interface GeoJSONProp {
   url?: string;
   geojson?: GeoJSON.FeatureCollection | GeoJSON.Feature | GeoJSON.GeometryCollection;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,34 +2,54 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { CircleMarkerOptions, TileLayerOptions } from "leaflet";
 import { engineStore } from "@wwtelescope/engine-pinia";
 
+/** The type of the WWT engine Pinia store */
 export type WWTEngineStore = ReturnType<typeof engineStore>;
 
 /* Funding acknowledgement */
 
+/** Interface describing props for the funding acknowledgement component */
 export interface FundingAcknowledgementProps {
+  /** The color of the acknowledgement text */
   color?: string;
+
+  /** The background color of the acknowledgement */
   backgroundColor?: string;
 }
 
 /* Credit logos */
 
+/** Interface describing props for the credit logos component */
 export interface CreditLogosProps {
-  visible?: boolean;
+  /** What size to use for the logos. Should be a valid CSS size. */
   logoSize?: string;
 }
 
 /* Gallery */
 
+/** Interface describing props for the gallery component */
 export interface GalleryProps {
+  /** The URL of a WTML file describing the desired gallery contents. Required */
   wtmlUrl: string;
+  /** The number of columns of the gallery.
+    * Accepts a number or a valid CSS value to be used in `repeat` for `grid-template-columns`
+    * Defaults to 'auto-fit'
+    */
   columns?: number | string;
+  /** The width of the gallery. Should be a valid CSS value for `width`. Defaults to 300px */
   width?: string;
+  /** Maximum height of the gallery. Should be a valid CSS value for `max-height`. Defaults to 500px */
   maxHeight?: string;
+  /** The title of the gallery. Default is 'Gallery' */
   title?: string;
+  /** The accent color to use for selected images in the gallery. Should be a valid CSS color. Default is 'dodgerblue' */
   selectedColor?: string;
+  /** Whether a user can select only one image at a time. Default true */
   singleSelect?: boolean;
+  /** Whether only the last selected image is highlighted. Default false */ 
   highlightLastOnly?: boolean;
+  /** The index of the preview image in the WTML file. Defaults to 0. */
   previewIndex?: number;
+  /** The text to show when the gallery is closed. Default is 'Image Gallery' */
   closedText?: string;
 }
 
@@ -37,6 +57,7 @@ export interface GalleryProps {
 
 export type GeolocationButtonDensity = null | "default" | "comfortable" | "compact";
 
+/** Interface describing props for the geolocation button */
 export interface GeolocationButtonProps {
   color?: string;
   disabled?: boolean;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,7 +17,7 @@ export function supportsTouchscreen(): boolean {
 
 /**
   * Determine whether a given user agent string describes a mobile device.
-  * This is done via a regex match.
+  * This is done via a regex match against common user agent string pieces.
   * @returns Whether the user agent string describes a mobile device
   */
 export function isMobile(userAgent: string): boolean {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,10 @@
+/** Degrees -> radians conversion factor */
 export const D2R = Math.PI / 180;
+/** Radians -> degrees conversion factor */
 export const R2D = 180 / Math.PI;
 
+/** The base URL for the CosmicDS API server */
 export const API_BASE_URL = "https://api.cosmicds.cfa.harvard.edu";
-export const MINIDS_BASE_URL = `${API_BASE_URL}/minids`;
 
 /**
   * Determine whether the user's device supports touch events.
@@ -18,6 +20,7 @@ export function supportsTouchscreen(): boolean {
 /**
   * Determine whether a given user agent string describes a mobile device.
   * This is done via a regex match against common user agent string pieces.
+  *
   * @returns Whether the user agent string describes a mobile device
   */
 export function isMobile(userAgent: string): boolean {
@@ -33,10 +36,11 @@ export function blurActiveElement() {
 }
 
 /**
-  * Filter an array in place (as opposed to .filter, which creates a new array)
+  * Filter an array in place (as opposed to .filter, which creates a new array).
   * Modified from https://stackoverflow.com/a/37319954
-  * @param{T[]} array - The array to filter
-  * @param{(t: T) => boolean} condition - The filtering condition. Elements for which this returns true are retained
+  *
+  * @param array - The array to filter
+  * @param condition - The filtering condition. Elements for which this returns true are retained
   * @template T
   */
 export function filterInPlace<T>(array: T[], condition: (t: T) => boolean) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,16 +4,27 @@ export const R2D = 180 / Math.PI;
 export const API_BASE_URL = "https://api.cosmicds.cfa.harvard.edu";
 export const MINIDS_BASE_URL = `${API_BASE_URL}/minids`;
 
-export function supportsTouchscreen() {
+/**
+  * Determine whether the user's device supports touch events.
+  *
+  * @returns Whether touch events are supported
+  */
+export function supportsTouchscreen(): boolean {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   return ('ontouchstart' in window) || ('ontouchstart' in document.documentElement) || !!window.navigator.msPointerEnabled;
 }
 
+/**
+  * Determine whether a given user agent string describes a mobile device.
+  * This is done via a regex match.
+  * @returns Whether the user agent string describes a mobile device
+  */
 export function isMobile(userAgent: string): boolean {
   return (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(userAgent));
 }
 
+/** Blur the current active element, if there is one */
 export function blurActiveElement() {
   const active = document.activeElement;
   if (active instanceof HTMLElement) {
@@ -21,7 +32,13 @@ export function blurActiveElement() {
   }
 }
 
-// Modified from https://stackoverflow.com/a/37319954
+/**
+  * Filter an array in place (as opposed to .filter, which creates a new array)
+  * Modified from https://stackoverflow.com/a/37319954
+  * @param{T[]} array - The array to filter
+  * @param{(t: T) => boolean} condition - The filtering condition. Elements for which this returns true are retained
+  * @template T
+  */
 export function filterInPlace<T>(array: T[], condition: (t: T) => boolean) {
   let i = 0;
   let j = 0;
@@ -34,5 +51,4 @@ export function filterInPlace<T>(array: T[], condition: (t: T) => boolean) {
   }
 
   array.length = j;
-  return array;
 }

--- a/src/wwt-utils.ts
+++ b/src/wwt-utils.ts
@@ -11,6 +11,12 @@ function doMove(store: WWTEngineStore, x: number, y: number) {
   store.move({ x, y });
 }
 
+/**
+  * A composable that sets up WWT keyboard controls.
+  * @param store The WWT engine's Pinia store
+  * @param element The element on which to attach the keyboard listeners. Uses the browser window if none is given
+  * @returns The `KeyboardControlSettings` instance that was used to create the listeners
+  */
 export function useWWTKeyboardControls(store: WWTEngineStore, element?: Window | HTMLElement): KeyboardControlSettings {
   const root = element || window;
   const kcs = new KeyboardControlSettings({});

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "https://typedoc.org/schema.json",
+    "entryPoints": ["./src/index.ts"],
+    "out": "docs"
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://typedoc.org/schema.json",
     "entryPoints": ["./src/index.ts"],
-    "out": "docs"
+    "out": "docs",
+    "exclude": ["**/*.vue", "src/shims-vue.d.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -304,6 +304,7 @@ __metadata:
     less-loader: ^12.1.0
     screenfull: ^6.0.2
     typedoc: ^0.25.13
+    typedoc-plugin-vue: ^1.1.0
     typescript: ^4.9.4
     vue: ^3
     vue-template-compiler: ^2.7.14
@@ -7607,6 +7608,15 @@ __metadata:
     media-typer: 0.3.0
     mime-types: ~2.1.24
   checksum: 2c8e47675d55f8b4e404bcf529abdf5036c537a04c2b20177bcf78c9e3c1da69da3942b1346e6edb09e823228c0ee656ef0e033765ec39a70d496ef601a0c657
+  languageName: node
+  linkType: hard
+
+"typedoc-plugin-vue@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "typedoc-plugin-vue@npm:1.1.0"
+  peerDependencies:
+    typedoc: 0.25.x
+  checksum: b689dab5716a38c76e9c0848932cb0118e2af3c482b0b0ea80c67680a006c6ee35a024db819b0dc972af52e572a04b0d008862c6874bca7d7547872cc2e6caac
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -303,6 +303,7 @@ __metadata:
     less: ^4.2.0
     less-loader: ^12.1.0
     screenfull: ^6.0.2
+    typedoc: ^0.25.13
     typescript: ^4.9.4
     vue: ^3
     vue-template-compiler: ^2.7.14
@@ -1790,6 +1791,13 @@ __metadata:
   version: 6.0.1
   resolution: "ansi-regex@npm:6.0.1"
   checksum: 1ff8b7667cded1de4fa2c9ae283e979fc87036864317da86a2e546725f96406746411d0d85e87a2d12fa5abd715d90006de7fa4fa0477c92321ad3b4c7d4e169
+  languageName: node
+  linkType: hard
+
+"ansi-sequence-parser@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "ansi-sequence-parser@npm:1.1.1"
+  checksum: ead5b15c596e8e85ca02951a844366c6776769dcc9fd1bd3a0db11bb21364554822c6a439877fb599e7e1ffa0b5f039f1e5501423950457f3dcb2f480c30b188
   languageName: node
   linkType: hard
 
@@ -4694,6 +4702,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsonc-parser@npm:^3.2.0":
+  version: 3.2.1
+  resolution: "jsonc-parser@npm:3.2.1"
+  checksum: 656d9027b91de98d8ab91b3aa0d0a4cab7dc798a6830845ca664f3e76c82d46b973675bbe9b500fae1de37fd3e81aceacbaa2a57884bf2f8f29192150d2d1ef7
+  languageName: node
+  linkType: hard
+
 "jsonfile@npm:^6.0.1":
   version: 6.1.0
   resolution: "jsonfile@npm:6.1.0"
@@ -4985,6 +5000,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lunr@npm:^2.3.9":
+  version: 2.3.9
+  resolution: "lunr@npm:2.3.9"
+  checksum: 176719e24fcce7d3cf1baccce9dd5633cd8bdc1f41ebe6a180112e5ee99d80373fe2454f5d4624d437e5a8319698ca6837b9950566e15d2cae5f2a543a3db4b8
+  languageName: node
+  linkType: hard
+
 "magic-string@npm:^0.30.7":
   version: 0.30.8
   resolution: "magic-string@npm:0.30.8"
@@ -5029,6 +5051,15 @@ __metadata:
     promise-retry: ^2.0.1
     ssri: ^10.0.0
   checksum: 7c7a6d381ce919dd83af398b66459a10e2fe8f4504f340d1d090d3fa3d1b0c93750220e1d898114c64467223504bd258612ba83efbc16f31b075cd56de24b4af
+  languageName: node
+  linkType: hard
+
+"marked@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "marked@npm:4.3.0"
+  bin:
+    marked: bin/marked.js
+  checksum: 0db6817893952c3ec710eb9ceafb8468bf5ae38cb0f92b7b083baa13d70b19774674be04db5b817681fa7c5c6a088f61300815e4dd75a59696f4716ad69f6260
   languageName: node
   linkType: hard
 
@@ -5175,6 +5206,15 @@ __metadata:
   dependencies:
     brace-expansion: ^1.1.7
   checksum: c154e566406683e7bcb746e000b84d74465b3a832c45d59912b9b55cd50dee66e5c4b1e5566dba26154040e51672f9aa450a9aef0c97cfc7336b78b7afb9540a
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^9.0.3":
+  version: 9.0.4
+  resolution: "minimatch@npm:9.0.4"
+  dependencies:
+    brace-expansion: ^2.0.1
+  checksum: cf717f597ec3eed7dabc33153482a2e8d49f4fd3c26e58fd9c71a94c5029a0838728841b93f46bf1263b65a8010e2ee800d0dc9b004ab8ba8b6d1ec07cc115b5
   languageName: node
   linkType: hard
 
@@ -6935,6 +6975,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"shiki@npm:^0.14.7":
+  version: 0.14.7
+  resolution: "shiki@npm:0.14.7"
+  dependencies:
+    ansi-sequence-parser: ^1.1.0
+    jsonc-parser: ^3.2.0
+    vscode-oniguruma: ^1.7.0
+    vscode-textmate: ^8.0.0
+  checksum: 2aec3b3519df977c4391df9e1825cb496e9a4d7e11395f05a0da77e4fa2f7c3d9d6e6ee94029ac699533017f2b25637ee68f6d39f05f311535c2704d0329b520
+  languageName: node
+  linkType: hard
+
 "side-channel@npm:^1.0.4":
   version: 1.0.6
   resolution: "side-channel@npm:1.0.6"
@@ -7558,6 +7610,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typedoc@npm:^0.25.13":
+  version: 0.25.13
+  resolution: "typedoc@npm:0.25.13"
+  dependencies:
+    lunr: ^2.3.9
+    marked: ^4.3.0
+    minimatch: ^9.0.3
+    shiki: ^0.14.7
+  peerDependencies:
+    typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x
+  bin:
+    typedoc: bin/typedoc
+  checksum: 703d1f48137300b0ef3df1998a25ae745db3ca0b126f8dd1f7262918f11243a94d24dfc916cdba2baeb5a7d85d5a94faac811caf7f4fa6b7d07144dc02f7639f
+  languageName: node
+  linkType: hard
+
 "typescript@npm:^4.9.4":
   version: 4.9.5
   resolution: "typescript@npm:4.9.5"
@@ -7691,6 +7759,20 @@ __metadata:
   version: 1.1.2
   resolution: "vary@npm:1.1.2"
   checksum: ae0123222c6df65b437669d63dfa8c36cee20a504101b2fcd97b8bf76f91259c17f9f2b4d70a1e3c6bbcee7f51b28392833adb6b2770b23b01abec84e369660b
+  languageName: node
+  linkType: hard
+
+"vscode-oniguruma@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "vscode-oniguruma@npm:1.7.0"
+  checksum: 53519d91d90593e6fb080260892e87d447e9b200c4964d766772b5053f5699066539d92100f77f1302c91e8fc5d9c772fbe40fe4c90f3d411a96d5a9b1e63f42
+  languageName: node
+  linkType: hard
+
+"vscode-textmate@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "vscode-textmate@npm:8.0.0"
+  checksum: 127780dfea89559d70b8326df6ec344cfd701312dd7f3f591a718693812b7852c30b6715e3cfc8b3200a4e2515b4c96f0843c0eacc0a3020969b5de262c2a4bb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR sets up documentation for our utility functions, composables, classes, and interfaces using [TypeDoc](https://typedoc.org/). TypeDoc uses JSDoc-style comments to generate docs.

However, this does not include our components, which is a pretty big blind spot for what is primarily a component library. That's intentional, for now - I plan on setting up [Storybook](https://storybook.js.org/) documentation for our components and integrating these TypeDoc docs into that. But I'll start with the non-component docs now, and set up Storybook in another PR soon.