### PR TITLE
Update dev dependencies to work around security issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "less": "^4.2.0",
     "less-loader": "^12.1.0",
     "markdown-loader": "^8.0.0",
+    "pug": "^3.0.3",
     "storybook": "^8.0.9",
     "storybook-css-modules-preset": "^1.1.1",
     "storybook-dark-mode": "^4.0.1",
@@ -52,7 +53,8 @@
     "typescript": "^4.9.4",
     "vue-loader": "^17.4.2",
     "vue-template-compiler": "^2.7.14",
-    "webpack": "^5.75.0"
+    "webpack": "^5.75.0",
+    "webpack-dev-middleware": "^5.3.4"
   },
   "files": [
     "dist/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1654,6 +1654,7 @@ __metadata:
     less: ^4.2.0
     less-loader: ^12.1.0
     markdown-loader: ^8.0.0
+    pug: ^3.0.3
     screenfull: ^6.0.2
     storybook: ^8.0.9
     storybook-css-modules-preset: ^1.1.1
@@ -1668,6 +1669,7 @@ __metadata:
     vue-template-compiler: ^2.7.14
     vuetify: ^3.3.3
     webpack: ^5.75.0
+    webpack-dev-middleware: ^5.3.4
   languageName: unknown
   linkType: soft
 
@@ -12221,10 +12223,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pug-code-gen@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "pug-code-gen@npm:3.0.3"
+  dependencies:
+    constantinople: ^4.0.1
+    doctypes: ^1.1.0
+    js-stringify: ^1.0.2
+    pug-attrs: ^3.0.0
+    pug-error: ^2.1.0
+    pug-runtime: ^3.0.1
+    void-elements: ^3.1.0
+    with: ^7.0.0
+  checksum: 7a494887eb2cbe88c90cd45f818729046d3cb186d5101770e158cc14be9cd5e664809c600182756ebbcab2b27caba87ac8b743e0ad0789799b1925a850612947
+  languageName: node
+  linkType: hard
+
 "pug-error@npm:^2.0.0":
   version: 2.0.0
   resolution: "pug-error@npm:2.0.0"
   checksum: c5372d018c897c1d6a141dd803c50957feecfda1f3d84a6adc6149801315d6c7f8c28b05f3e186d98d774fc9718699d1e1caa675630dd3c4453f8c5ec4e4a986
+  languageName: node
+  linkType: hard
+
+"pug-error@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "pug-error@npm:2.1.0"
+  checksum: e084890365f1c03a828437c1dcf641598f5754bc0fdde625a8b2529c52fbda0caa89e0e29e9124d665cfd3915bb8916011787861930a0dcf250d46e1a33c1e5c
   languageName: node
   linkType: hard
 
@@ -12318,6 +12343,22 @@ __metadata:
     pug-runtime: ^3.0.1
     pug-strip-comments: ^2.0.0
   checksum: 3e1a3d48897c0c7dedd4f959ce8afaf6417a63756b149e1b5382bef16de5792ec7c7ae6a7d41641059cb149520f20b0d1ecf57014c0661526e96f0bad88541e5
+  languageName: node
+  linkType: hard
+
+"pug@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "pug@npm:3.0.3"
+  dependencies:
+    pug-code-gen: ^3.0.3
+    pug-filters: ^4.0.0
+    pug-lexer: ^5.0.1
+    pug-linker: ^4.0.0
+    pug-load: ^3.0.0
+    pug-parser: ^6.0.0
+    pug-runtime: ^3.0.1
+    pug-strip-comments: ^2.0.0
+  checksum: b825497b44fb373625680c0279199f964fd7446351f5570087d4b7f73e7855434ff075d3085fd11c08473dc355719b0613d20e3d44f197b1809736c1d5f8370b
   languageName: node
   linkType: hard
 
@@ -14938,6 +14979,21 @@ __metadata:
   peerDependencies:
     webpack: ^4.0.0 || ^5.0.0
   checksum: dd332cc6da61222c43d25e5a2155e23147b777ff32fdf1f1a0a8777020c072fbcef7756360ce2a13939c3f534c06b4992a4d659318c4a7fe2c0530b52a8a6621
+  languageName: node
+  linkType: hard
+
+"webpack-dev-middleware@npm:^5.3.4":
+  version: 5.3.4
+  resolution: "webpack-dev-middleware@npm:5.3.4"
+  dependencies:
+    colorette: ^2.0.10
+    memfs: ^3.4.3
+    mime-types: ^2.1.31
+    range-parser: ^1.2.1
+    schema-utils: ^4.0.0
+  peerDependencies:
+    webpack: ^4.0.0 || ^5.0.0
+  checksum: 90cf3e27d0714c1a745454a1794f491b7076434939340605b9ee8718ba2b85385b120939754e9fdbd6569811e749dee53eec319e0d600e70e0b0baffd8e3fb13
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Dependabot warned us about a couple of high-severity security issues with some packages that we have in our dependency tree. This PR updates those package versions to resolve them.