### PR TITLE
Use release tag to set package version when publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,22 +3,46 @@ on:
   release:
     types: [published]
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v3
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-      - run: corepack enable
+
+      - name: Get package version from release tag
+        uses: sergeysova/jq-action@v2
+        env:
+          VERSION: ${{ github.event.release.tag_name }}
+        with:
+          cmd: cat package.json | jq ".version = \"$VERSION\"" > package.json
+
+      - name: Enable corepack
+        run: corepack enable
+
       # This should match the version set in package.json
-      - run: yarn set version 3.3.0
-      - run: yarn
-      - run: yarn build
-      - run: 'echo "npmAuthToken: ${NPM_PUBLISH_TOKEN}" >> .yarnrc.yml'
+      - name: Set yarn version
+        run: yarn set version 3.3.0
+
+      - name: yarn install
+        run: yarn
+
+      - name: Lint package
+        run: yarn lint
+
+      - name: Build package
+        run: yarn build
+
+      - name: Set up yarn for publishing
+        run: 'echo "npmAuthToken: ${NPM_PUBLISH_TOKEN}" >> .yarnrc.yml'
         env:
           NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-      - run: yarn npm publish
+
+      - name: Publish package
+        run: yarn npm publish
 

--- a/package.json
+++ b/package.json
@@ -73,5 +73,6 @@
     "storybook": "storybook dev -p 6006 --debug",
     "build-storybook": "storybook build -o docs"
   },
-  "types": "./dist/src/index.d.ts"
+  "types": "./dist/src/index.d.ts",
+  "version": "0.0.0-dev.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@cosmicds/vue-toolkit",
-  "version": "0.4.0",
   "browser": "dist/index.umd.js",
   "dependencies": {
     "@capacitor/core": "^5.7.4",


### PR DESCRIPTION
This PR resolves #20. It removes the current version from our package file (replacing it with a dummy version) and updates the release workflow to use the current release tag to set the version.