### PR TITLE
Use hyphen rather than plus as button ID separator

### DIFF
--- a/src/components/GeolocationButton.vue
+++ b/src/components/GeolocationButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <span :id="`geolocation-wrapper+${id}`" class="geolocation">
+  <span :id="`geolocation-wrapper-${id}`" class="geolocation">
     <span v-if="showPermissions">Geolocation {{ permissions }} </span>
     <span v-if="showPermissions">location {{ geolocation }} </span>
     <span v-if="showPermissions">counter {{ counter }} </span>


### PR DESCRIPTION
Currently the geolocation button ID is generated via the `id` prop is `geolocation-wrapper+${id}`. The plus sign makes things a bit difficult due to the fact that `+` is the next-sibling combinator. While we can do things like `#geolocation-wrapper\\+<id>`, this is annoying and easy to miss. This PR changes the generated ID to be `geolocation-wrapper-${id}`.