### PR TITLE
Add location search component

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Build Storybook
         run: yarn build-storybook 
+        env:
+          VUE_APP_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -17,6 +17,7 @@ const config: StorybookConfig = {
   docs: {
     autodocs: "tag",
   },
+  env: (config) => config,
   webpackFinal: async (config) => {
     config.module?.rules?.push({
       test: /\.less/,

--- a/src/components/LocationSearch.vue
+++ b/src/components/LocationSearch.vue
@@ -49,9 +49,15 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { faMagnifyingGlass } from "@fortawesome/free-solid-svg-icons";
+import { VCombobox } from "vuetify/lib/components/index.mjs";
 
 import { MapBoxFeature, MapBoxFeatureCollection, textForMapboxFeature } from "../mapbox";
 import { SearchProvider, LocationSearchProps } from "../types";
+
+library.add(faMagnifyingGlass);
 
 const props = withDefaults(defineProps<LocationSearchProps>(), {
   searchProvider: (async (_searchText: string) => null) as SearchProvider,

--- a/src/components/LocationSearch.vue
+++ b/src/components/LocationSearch.vue
@@ -1,0 +1,243 @@
+<template>
+  <div
+    class="forward-geocoding-container"
+    :style="cssStyles"
+  >
+    <v-combobox
+      v-show="searchOpen"
+      :class="['forward-geocoding-input', locationJustUpdated ? 'geocode-success' : '', small ? 'forward-geocoding-input-small' : '']"
+      v-model="searchItem"
+      :items="searchResults ? searchResults.features : []"
+      :item-title="itemText"
+      :bg-color="bgColor"
+      label="Enter city or zip"
+      :density="small ? 'compact' : 'default'"
+      hide-details
+      solo
+      :color="accentColor"
+      @input="() => {}"
+      @keydown.enter="performForwardGeocodingSearch"
+      @keydown.esc="searchResults = null"
+      @keydown.stop
+      :error-messages="searchErrorMessage"
+      @click:append="focusCombobox"
+      @update:focused="onFocusChange($event)"
+      ref="searchInput"
+      :menu="menuOpen"
+      @update:menu="menuOpen = $event"
+    >
+    <template v-slot:append>
+      <font-awesome-icon
+        class="geocoding-search-icon"
+        icon="magnifying-glass"
+        :size="searchOpen ? 'xl' : buttonSize"
+        color="gray"
+        @click="toggleSearch"
+      ></font-awesome-icon>
+    </template>
+  </v-combobox>
+  <font-awesome-icon
+      v-show="!searchOpen && !stayOpen"
+      class="geocoding-search-icon"
+      icon="magnifying-glass"
+      :size="searchOpen ? 'xl' : buttonSize"
+      color="gray"
+      @click.prevent="toggleSearch"
+    ></font-awesome-icon>
+  </div>
+</template> 
+
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+
+import { MapBoxFeature, MapBoxFeatureCollection, textForMapboxFeature } from "../mapbox";
+import { SearchProvider, LocationSearchProps } from "../types";
+
+const props = withDefaults(defineProps<LocationSearchProps>(), {
+  searchProvider: (async (_searchText: string) => null) as SearchProvider,
+  modelValue: true,
+  stayOpen: false,
+  accentColor: "white",
+  small: false,
+  buttonSize: "1x",
+  bgColor: "black",
+});
+
+const emit = defineEmits<{
+  (e: "error", message: string): void
+  (e: "set-location", feature: MapBoxFeature): void
+  (e: "update:modelValue", value: boolean): void
+}>();
+
+const searchOpen = ref(props.modelValue || props.stayOpen);
+const searchItem = ref<string | null>(null);
+const searchResults = ref<MapBoxFeatureCollection | null>(null);
+const searchErrorMessage = ref<string | null>(null);
+const locationJustUpdated = ref(false);
+const menuOpen = ref(false);
+const comboFocused = ref(false);
+const searchInput = ref<HTMLInputElement | null>(null);
+
+const cssStyles = computed(() => {
+  return {
+    "--accent-color": props.accentColor,
+    "--bg-color": props.bgColor,
+    "--fg-container-padding": searchOpen.value ? (props.small ? "0px 5px 0px 0px" : "5px 10px 12px 10px") : "0px",
+    "--border-radius": searchOpen.value ? "7px" : "20px",
+  };
+});
+
+function itemText(item: string | MapBoxFeature): string {
+  if (typeof item === "string") {
+    return item;
+  }
+  return textForMapboxFeature(item);
+}
+
+function performForwardGeocodingSearch() {
+  const search = searchItem.value;
+  if (search === null || search.length < 3) {
+    return;
+  }
+
+  props.searchProvider(search).then(info => {
+    if (info !== null && info.features.length === 1) {
+      setLocationFromSearchFeature(info.features[0]);
+    } else if (info !== null && info.features.length === 0) {
+      searchErrorMessage.value = "No matching places were found";
+      emit("error", searchErrorMessage.value); 
+    } else {
+      searchResults.value = info;
+    }
+  });
+}
+
+function focusCombobox() {
+  const input = searchInput.value as HTMLInputElement;
+  input.focus();
+}
+
+function blurCombobox() {
+  const input = searchInput.value as HTMLInputElement;
+  input.blur();
+}
+
+function toggleSearch() {
+  if (searchOpen.value) {
+    performForwardGeocodingSearch();
+    menuOpen.value = true;
+    focusCombobox();
+  } else {
+    searchOpen.value = true;
+  }
+}
+
+// function closeSearch() {
+//   searchOpen.value = false;
+//   clearSearchData();
+// }
+
+function onFocusChange(focused: boolean) {
+  comboFocused.value = focused;
+}
+
+function setLocationFromSearchFeature(feature: MapBoxFeature) {
+  blurCombobox();
+  timedJustUpdatedLocation();
+  clearSearchData();
+  emit("set-location", feature);
+}
+
+function clearSearchData() {
+  searchResults.value = null;
+  searchItem.value = null;
+  searchErrorMessage.value = null;
+}
+
+function timedJustUpdatedLocation() {
+  locationJustUpdated.value = true;
+  setTimeout(() => {
+    locationJustUpdated.value = false;
+  }, 5000);
+}
+
+watch(() => props.modelValue, (value: boolean) => { searchOpen.value = value; });
+
+watch(searchOpen, (value: boolean) => emit("update:modelValue", value));
+
+watch(searchItem, function(item: string | MapBoxFeature | null) {
+  if (searchErrorMessage.value) {
+    searchErrorMessage.value = null;
+  }
+  if (!item || (typeof item === "string" && item.length === 0)) {
+    searchResults.value = null;
+  }
+  if (item && typeof item !== "string") {
+    setLocationFromSearchFeature(item);
+  }
+});
+</script>
+
+<style lang="less">
+
+// https://vue-loader.vuejs.org/guide/scoped-css.html#deep-selectors
+.forward-geocoding-container {
+  --border-radius: 20px;
+  position: relative;
+  color: var(--accent-color);
+  border: 2px solid var(--accent-color);
+  border-radius: var(--border-radius);
+  background-color: var(--bg-color);
+  margin-left: 0.25rem;
+  margin-bottom: 0.25rem;
+  padding: var(--fg-container-padding);
+
+  // there are two separate labels, we want the 2nd one to be large. the first is the small floating label
+  .v-field > .v-field__field > .v-label.v-field-label:nth-child(2) {
+    font-size: 1.2rem;
+  }
+
+  // .v-input--horizontal .v-input__append {
+  //   margin-inline-start: 0;
+  // }
+  
+  .v-text-field {
+    min-width: 150px;
+  }
+  
+  .v-field--variant-filled.v-field--has-background .v-field__overlay {
+    border-top-right-radius: 0px;
+}
+
+  .forward-geocoding-input > .v-input__control > .v-field {
+    border-radius: var(--border-radius);
+  }
+  
+  .forward-geocoding-input.geocode-success label {
+    opacity: 1;
+  }
+  
+  .forward-geocoding-input-small label {
+    // .v-label sets default to 1rem
+    font-size: 0.8rem;
+  }
+
+  .forward-geocoding-input-row {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-around;
+    gap: 10px;
+    align-items: center;
+  }
+  
+  .geocoding-search-icon {
+    padding-inline: calc(0.3 * var(--default-line-height));
+    padding-block: calc(0.4 * var(--default-line-height));
+  }
+
+  .geocoding-search-icon:hover, #geocoding-close-icon:hover {
+    cursor: pointer;
+  }
+
+}
+</style>

--- a/src/components/LocationSearch.vue
+++ b/src/components/LocationSearch.vue
@@ -106,7 +106,7 @@ function performForwardGeocodingSearch() {
     return;
   }
 
-  props.searchProvider(search).then(info => {
+  props.searchProvider(search).then((info: MapBoxFeatureCollection | null) => {
     if (info !== null && info.features.length === 1) {
       setLocationFromSearchFeature(info.features[0]);
     } else if (info !== null && info.features.length === 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import FundingAcknowledgement from "./components/FundingAcknowledgement.vue";
 import Gallery from "./components/Gallery.vue";
 import GeolocationButton from "./components/GeolocationButton.vue";
 import IconButton from "./components/IconButton.vue";
+import LocationSearch from "./components/LocationSearch.vue";
 import LocationSelector from "./components/LocationSelector.vue";
 import PlaybackControl from "./components/PlaybackControl.vue";
 import SpeedControl from "./components/SpeedControl.vue";
@@ -37,6 +38,7 @@ export {
   Gallery,
   GeolocationButton,
   IconButton,
+  LocationSearch,
   LocationSelector,
   PlaybackControl,
   SpeedControl,

--- a/src/stories/LocationSearch.stories.ts
+++ b/src/stories/LocationSearch.stories.ts
@@ -23,9 +23,10 @@ export const Primary: Story = {
           <LocationSearch
             v-bind="args"
             @set-location="(loc) => {
-              document.querySelector('#selected-location').innerHTML = textForMapboxFeature(loc);
+              $el.querySelector('#selected-location').innerHTML = textForMapboxFeature(loc);
             }"
           />
+          <hr style="margin: 30px">
           <div>The last selected location is <span id="selected-location">none</span></div>
         </div>
       `,
@@ -35,7 +36,7 @@ export const Primary: Story = {
     };
   },
   args: {
-    searchProvider: (searchText: string) => geocodingInfoForSearch(searchText, { access_token: process.env.VUE_APP_MAPBOX_TOKEN ?? "" }),
+    searchProvider: (searchText: string) => geocodingInfoForSearch(searchText, { access_token: process.env.VUE_APP_MAPBOX_ACCESS_TOKEN ?? "" }),
     modelValue: true,
     stayOpen: true,
     accentColor: "orange",

--- a/src/stories/LocationSearch.stories.ts
+++ b/src/stories/LocationSearch.stories.ts
@@ -1,0 +1,46 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+import { Meta, StoryObj } from "@storybook/vue3";
+import { LocationSearchProps, LocationSearch, geocodingInfoForSearch, textForMapboxFeature } from "..";
+
+import "./stories.css";
+
+const meta: Meta<typeof LocationSearch> = {
+  component: LocationSearch,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof LocationSearch>;
+
+export const Primary: Story = {
+  render: (args: LocationSearchProps) => {
+
+    return {
+      components: { LocationSearch },
+      template: `
+        <div style="width: 900px; height: 400px">
+          <LocationSearch
+            v-bind="args"
+            @set-location="(loc) => {
+              document.querySelector('#selected-location').innerHTML = textForMapboxFeature(loc);
+            }"
+          />
+          <div>The last selected location is <span id="selected-location">none</span></div>
+        </div>
+      `,
+      setup() {
+        return { args, textForMapboxFeature };
+      }
+    };
+  },
+  args: {
+    searchProvider: (searchText: string) => geocodingInfoForSearch(searchText, { access_token: process.env.VUE_APP_MAPBOX_TOKEN ?? "" }),
+    modelValue: true,
+    stayOpen: true,
+    accentColor: "orange",
+    bgColor: "black",
+    buttonSize: "1x",
+    small: false,
+  }
+};

--- a/src/stories/LocationSelector.stories.ts
+++ b/src/stories/LocationSelector.stories.ts
@@ -17,7 +17,6 @@ const location = ref({
   latitudeDeg: 42.3814,
   longitudeDeg: -71.1281,
 });
-console.log(location);
 export const Primary: Story = {
   render: (args: LocationSelectorProps) => ({
     components: { LocationSelector },

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { CircleMarkerOptions, TileLayerOptions } from "leaflet";
 import { engineStore } from "@wwtelescope/engine-pinia";
+import { MapBoxFeatureCollection } from "./mapbox";
 
 /** The type of the WWT engine Pinia store */
 export type WWTEngineStore = ReturnType<typeof engineStore>;
@@ -314,4 +315,25 @@ export interface SpeedControlProps {
   showStatus?: boolean;
   /** The factor by which to adjust the WWT speed when speeding up or down */ 
   rateDelta?: number;
+}
+
+/** An async function taking an input string and returning a collection of MapBox Features */
+export type SearchProvider = (searchText: string) => Promise<MapBoxFeatureCollection | null>;
+
+/** Interface describing props for the location search component */
+export interface LocationSearchProps {
+  /** The search provider function to use for finding MapBox features */
+  searchProvider?: SearchProvider;
+  /** Whether or not the location search is open */
+  modelValue?: boolean;
+  /** Whether the search box should stay open after a search is completed */
+  stayOpen?: boolean;
+  /** The accent color used for the search box. Should be a valid CSS color */
+  accentColor?: string;
+  /** Whether to use the "small-screen" layout */
+  small?: boolean;
+  /** The size of the activator button's icon. Should be a valid FontAwesome icon size */
+  buttonSize?: string;
+  /** The background color of the search box. Should be a valid CSS color */
+  bgColor?: string;
 }


### PR DESCRIPTION
This PR resolves #28 by adding the location search component, along with a story that shows this component at work - when the user selects a location using the box, the story has a div whose text will update to tell the last selected location.

Making this work on the docs page requires our MapBox access token, so this PR also injects that into the Storybook build environment. I don't anticipate that we'll see enough usage to make a significant dent in our monthly free allotment, but we can see how it goes.