### PR TITLE
Add date/time picker component

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,12 @@ jobs:
       - name: Build
         run: yarn build
 
+        # We're only building here, not actually testing
+        # so it doesn't matter that we don't actually have the MapBox token.
+        # We just need to have something, or the build will fail as Storybook
+        # won't be able to find the environment variable.
       - name: Build Storybook 
         run: yarn build-storybook
+        env:
+          VUE_APP_MAPBOX_ACCESS_TOKEN: ""
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,5 +41,5 @@ jobs:
       - name: Build Storybook 
         run: yarn build-storybook
         env:
-          VUE_APP_MAPBOX_ACCESS_TOKEN: "test"
+          VUE_APP_MAPBOX_ACCESS_TOKEN: test
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,5 +41,5 @@ jobs:
       - name: Build Storybook 
         run: yarn build-storybook
         env:
-          VUE_APP_MAPBOX_ACCESS_TOKEN: ""
+          VUE_APP_MAPBOX_ACCESS_TOKEN: "test"
 

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -19,7 +19,7 @@ const config: StorybookConfig = {
   },
   env: (config) => ({
     ...config,
-    VUE_APP_MAPBOX_ACCESS_TOKEN: process.env.VUE_APP_MAPBOX_ACCESS_TOKEN,
+    VUE_APP_MAPBOX_ACCESS_TOKEN: process.env.VUE_APP_MAPBOX_ACCESS_TOKEN ?? "",
   }),
   webpackFinal: async (config) => {
     config.module?.rules?.push({

--- a/src/components/DateTimePicker.vue
+++ b/src/components/DateTimePicker.vue
@@ -1,6 +1,6 @@
 <!-- Design Inspired by Date/Time Picker at Stellarium Web https://stellarium-web.org/ -->
 <template>
-  <div class="dtp__container">
+  <div class="dtp__container" :style="cssStyles">
     <div class="dtp__row">
       <div class="dtp__grid-container">
 
@@ -164,6 +164,7 @@ const props = withDefaults(defineProps<DateTimePickerProps>(), {
   debug: false,
   useAmPm: true,
   editableTime: true,
+  accentColor: "#f4ba3e",
 });
 
 const emit = defineEmits<{
@@ -176,6 +177,12 @@ const day = ref(props.modelValue.getDate());
 const hour = ref(props.modelValue.getHours());
 const minute = ref(props.modelValue.getMinutes());
 const second = ref(props.modelValue.getSeconds());
+
+const cssStyles = computed(() => {
+  return {
+    "--accent-color": props.accentColor,
+  };
+});
 
 const isAm = computed({
   get: () => hour.value < 12,

--- a/src/components/DateTimePicker.vue
+++ b/src/components/DateTimePicker.vue
@@ -1,0 +1,482 @@
+<!-- Design Inspired by Date/Time Picker at Stellarium Web https://stellarium-web.org/ -->
+<template>
+  <div class="dtp__container">
+    <div class="dtp__row">
+      <div class="dtp__grid-container">
+
+        <!-- 1-1 -->
+        <button id="dtp__year-up" class="dtp__grid-item" @click="increment('year')">
+          <span class="dtp__button-label">yr</span>
+          <v-icon>mdi-menu-up</v-icon>
+        </button>
+        <!-- 2-1 -->
+        <tap-to-input :editable="props.editableTime" id="dtp__year" class="dtp__grid-item dtp__time_part" :min="limits.year.min" :max="limits.year.max" v-model="year" />
+        <!-- 3-1 -->
+        <button id="dtp__year-up" class="dtp__grid-item" @click="decrement('year')">
+          <v-icon>mdi-menu-down</v-icon>
+        </button>
+
+        <!-- 1-2 -->
+        <span></span>
+        <!-- 2-2 -->
+        <span>-</span>
+        <!-- 3-2 -->
+        <span></span>
+
+        <!-- 1-3 -->
+        <button id="dtp__month-up" class="dtp__grid-item" @click="increment('month')">
+          <span class="dtp__button-label">mo</span>
+          <v-icon>mdi-menu-up</v-icon>
+        </button>
+        <!-- 2-3 -->
+        <tap-to-input :editable="props.editableTime" id="dtp__month" class="dtp__grid-item dtp__time_part" :min="limits.month.min" :max="limits.month.max" pad2 v-model="month" />
+        <!-- 3-3 -->
+        <button id="dtp__month-up" class="dtp__grid-item" @click="decrement('month')">
+          <v-icon>mdi-menu-down</v-icon>
+        </button>
+
+        <!-- 1-4 -->
+        <span></span>
+        <!-- 2-4 -->
+        <span>-</span>
+        <!-- 3-4 -->
+        <slot name="bottom-middle"><span></span></slot>
+
+        <!-- 1-5 -->
+        <button id="dtp__day-up" class="dtp__grid-item" @click="increment('day')">
+          <span class="dtp__button-label">day</span>
+          <v-icon>mdi-menu-up</v-icon>
+        </button>
+        <!-- 2-5 -->
+        <tap-to-input :editable="props.editableTime" id="dtp__day" class="dtp__grid-item dtp__time_part" :min="limits.day.min" :max="limits.day.max" pad2 v-model="day" />
+        <!-- 3-5 -->
+        <button id="dtp__day-up" class="dtp__grid-item" @click="decrement('day')">
+          <v-icon>mdi-menu-down</v-icon>
+        </button>
+
+        <!-- 1-6 -->
+        <slot name="top-middle"><span></span></slot>
+        <!-- 2-6 -->
+        <span class="dtp__middle-slot"><slot name="center-middle"></slot></span>
+        <!-- 3-6 -->
+        <span></span>
+
+        <!-- 1-7 -->
+        <button id="dtp__hour-up" class="dtp__grid-item" @click="increment('hour')">
+          <span class="dtp__button-label">hr</span>
+          <v-icon>mdi-menu-up</v-icon>
+        </button>
+        <!-- 2-7 -->
+        <tap-to-input :editable="props.editableTime" id="dtp__hour" class="dtp__grid-item dtp__time_part" :min="limits.hour.min" :max="limits.hour.max" pad2 v-model="displayHour" />
+        <!-- 3-7 -->
+        <button id="dtp__hour-up" class="dtp__grid-item" @click="decrement('hour')">
+          <v-icon>mdi-menu-down</v-icon>
+        </button>
+
+        <!-- 1-8 -->
+        <span></span>
+        <!-- 2-8 -->
+        <span>:</span>
+        <!-- 3-8 -->
+        <span></span>
+
+        <!-- 1-9 -->
+        <button id="dtp__minute-up" class="dtp__grid-item" @click="increment('minute')">
+          <span class="dtp__button-label">min</span>
+          <v-icon>mdi-menu-up</v-icon>
+        </button>
+        <!-- 2-9 -->
+        <tap-to-input :editable="props.editableTime" id="dtp__minute" class="dtp__grid-item dtp__time_part" :min="limits.minute.min" :max="limits.minute.max" pad2 v-model="minute" />
+        <!-- 3-9 -->
+        <button id="dtp__minute-up" class="dtp__grid-item" @click="decrement('minute')">
+          <v-icon>mdi-menu-down</v-icon>
+        </button>
+
+        <!-- 1-10 -->
+        <span></span>
+        <!-- 2-10 -->
+        <span>:</span>
+        <!-- 3-10 -->
+        <span></span>
+
+        <!-- 1-11 -->
+        <button id="dtp__second-up" class="dtp__grid-item" @click="increment('second')">
+          <span class="dtp__button-label">sec</span>
+          <v-icon>mdi-menu-up</v-icon>
+        </button>
+        <!-- 2-11 -->
+        <tap-to-input :editable="props.editableTime" id="dtp__second" class="dtp__grid-item dtp__time_part" :min="limits.second.min" :max="limits.second.max" pad2 v-model="second" />
+        <!-- 3-11 -->
+        <button id="dtp__second-up" class="dtp__grid-item" @click="decrement('second')">
+          <v-icon>mdi-menu-down</v-icon>
+        </button>
+
+        <!-- <div class="dtp__rollers up-rollers"> -->
+        <!-- </div> -->
+
+        <!-- <span class="dtp__time-string"> -->
+        <!-- <span id="dtp__year" class="dtp__grid-item dtp__time_part">{{ year }}</span> -->
+
+        <!-- <span id="dtp__month" class="dtp__grid-item dtp__time_part">{{ pad2(month) }}</span> -->
+        <!-- <span id="dtp__day" class="dtp__grid-item dtp__time_part">{{ pad2(day) }}</span>  -->
+        <!-- <span id="dtp__hour" class="dtp__grid-item dtp__time_part">{{ pad2(displayHour) }}</span> -->
+        <!-- <span id="dtp__minute" class="dtp__grid-item dtp__time_part">{{ pad2(minute) }}</span> -->
+        <!-- <span id="dtp__second" class="dtp__grid-item dtp__time_part">{{ pad2(second) }}</span> -->
+        <!-- </span> -->
+
+      </div>
+      
+      <div class="dtp__ampm" v-if="props.useAmPm">
+        <button 
+          name="set-am" 
+          :class='["dtp__ampm-button", "dtp__ampm-am", { "dtp__ampm-active": isAm }]' 
+          @click="isAm = true" 
+          aria-label="Set AM"
+          >AM</button>
+        <button 
+          name="set-pm" 
+          :class='["dtp__ampm-button", "dtp__ampm-pm", { "dtp__ampm-active": !isAm }]' 
+          @click="isAm = false" 
+          aria-label="Set PM"
+          >PM</button>
+      </div>
+    </div>
+    
+    <div class="dtp__bottom-content">
+      <slot></slot>
+    </div>
+    <div v-if="props.debug" class="dtp__debug">
+      <span>Local: {{ year }}-{{ pad2(month) }}-{{ pad2(day) }} {{ pad2(hour) }}:{{ pad2(minute) }}:{{ pad2(second) }}</span>
+      <span>UTC: {{ utcDate(modelValue) }} </span>
+    </div>
+
+  </div>
+
+</template>
+
+
+<script setup lang="ts">
+import { ref, watch, computed } from 'vue';
+import TapToInput from './TapToInput.vue';
+import { DateTimePickerProps } from "../types";
+
+const props = withDefaults(defineProps<DateTimePickerProps>(), {
+  debug: false,
+  useAmPm: true,
+  editableTime: true,
+});
+
+const emit = defineEmits<{
+  (event: "update:modelValue", datetime: Date): void
+}>();
+
+const year = ref(props.modelValue.getFullYear());
+const month = ref(props.modelValue.getMonth()+1);
+const day = ref(props.modelValue.getDate());
+const hour = ref(props.modelValue.getHours());
+const minute = ref(props.modelValue.getMinutes());
+const second = ref(props.modelValue.getSeconds());
+
+const isAm = computed({
+  get: () => hour.value < 12,
+  set: (value) => {
+    if (value) {
+      for (let i = 0; i < 12; i++) {
+        decrement('hour');
+      }
+    } else {
+      for (let i = 0; i < 12; i++) {
+        increment('hour');
+      }
+    }
+  }
+});
+
+const values = {
+  year: year,
+  month: month,
+  day: day,
+  hour: hour,
+  minute: minute,
+  second: second,
+};
+
+type Unit = 'year' | 'month' | 'day' | 'hour' | 'minute' | 'second';
+
+const limits = computed(() => ({
+  year: { min: 1, max: Infinity },
+  month: { min: 1, max: 12 },
+  day: { min: 1, max: _daysInMonth(month.value, year.value) },
+  hour: { min: 0, max: 23 },
+  minute: { min: 0, max: 59 },
+  second: { min: 0, max: 59 },
+}));
+
+const units: Unit[] = ['second', 'minute', 'hour', 'day', 'month', 'year'];
+
+function changeValue(unit: Unit, increment: boolean) {
+  const limit = limits.value[unit].max;
+  const min = limits.value[unit].min;
+
+  if (increment) {
+    if (values[unit].value < limit) {
+      values[unit].value++;
+    } else {
+      values[unit].value = min;
+      const nextUnit = units[units.indexOf(unit) + 1];
+      if (nextUnit) {
+        changeValue(nextUnit, increment);
+      } else if (unit === 'hour' && props.useAmPm) {
+        // Toggle AM/PM when hour goes from 11 to 12
+        isAm.value = !isAm.value;
+      }
+    }
+  } else {
+    if (values[unit].value > min) {
+      values[unit].value--;
+    } else {
+      values[unit].value = limit;
+      const prevUnit = units[units.indexOf(unit) + 1];
+      if (prevUnit) {
+        changeValue(prevUnit, increment);
+      } else if (unit === 'hour' && props.useAmPm) {
+        // Toggle AM/PM when hour goes from 12 to 11
+        isAm.value = !isAm.value;
+      }
+    }
+  }
+
+  // Ensure hour is always between 0 and 23
+  if (unit === 'hour') {
+    hour.value = hour.value % 24;
+  }
+}
+
+const displayHour = computed({
+  get() {
+    if (props.useAmPm) {
+      const h = hour.value % 12;
+      return h === 0 ? 12 : h;
+    } else {
+      return hour.value;
+    }
+  },
+  set(value: number) {
+    if (props.useAmPm) {
+      if (value === 12) {
+        hour.value = isAm.value ? 0 : 12;
+      } else {
+        hour.value = isAm.value ? value : value + 12;
+      }
+    } else {
+      hour.value = value;
+    }
+  }
+});
+
+function increment(value: Unit) {
+  changeValue(value, true);
+}
+
+function decrement(value: Unit) {
+  changeValue(value, false);
+}
+
+function _daysInMonth(month: number, year: number) {
+  return new Date(year, month, 0).getDate();
+}
+
+
+function utcDate(date: Date) {
+  // utc date string
+  return date.toISOString(); 
+}
+
+function pad2(n: number) {
+  return n.toString().padStart(2, '0');
+}
+
+// update the date v-model
+watch([year, month, day, hour, minute, second], () => {
+  const newDate = new Date(year.value, month.value-1, day.value, hour.value, minute.value, second.value);
+  emit("update:modelValue", newDate);
+});
+
+// watcher to fix leap years
+watch([year, month, day, hour, minute, second], () => {
+  if (month.value === 2 && day.value > _daysInMonth(month.value, year.value)) {
+    day.value = _daysInMonth(month.value, year.value);
+  }
+});
+// after we have mounted make the up and down buttons the same width
+// keep this up to date with the model value
+watch(() => props.modelValue, (date) => {
+  year.value = date.getFullYear();
+  month.value = date.getMonth()+1;
+  day.value = date.getDate();
+  hour.value = date.getHours();
+  minute.value = date.getMinutes();
+  second.value = date.getSeconds();
+});
+
+</script>
+
+<style lang="less">
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+Mono:wght@500&display=swap');
+
+.dtp__container {
+  padding-top: 1.5em;
+  padding-bottom: 5px;
+  padding-inline: 15px;
+}
+
+@media (max-width: 350px) {
+  .dtp__container {
+    font-size: 5vw;
+  }
+}
+
+.dtp__grid-container {
+  display: grid;
+  grid-auto-flow: column;
+  grid-template-columns: repeat(11, 0fr);
+  grid-template-rows: auto auto auto;
+  justify-items: center;
+  justify-content: center;
+  font-family: 'Noto Sans Mono', monospace;
+  gap: 2px;
+  margin-bottom: 10px;
+}
+
+.dtp__row {
+  display: grid;
+  grid-template-columns: 0fr 0fr;
+  align-items: center;
+  gap: 1em;
+}
+
+@media (max-width: 350px) {
+  .dtp__row {
+    display: grid;
+    grid-template-columns: 0fr;
+    grid-template-rows: 0fr 0fr;
+    justify-items: center;
+    gap: 2px;
+  }
+}
+
+.dtp__grid-container > * {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+}
+
+.dtp__middle-slot {
+  width: 1.5em;
+}
+
+.dtp__bottom-content {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.dtp__grid-item {
+  position: relative;
+  // outline: 1px solid red;
+  text-align: center;
+}
+
+span.dtp__button-label {
+  font-size: 0.8em;
+  // display: none;
+  position:absolute;
+  top: -5px;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  // outline: 1px solid red;
+}
+
+.dtp__ampm {
+  display: grid;
+  grid-template-columns: 3em;
+  grid-template-rows: 0fr 0fr;
+  gap: 1px;
+}
+
+.dtp__ampm-button {
+  background-color: #444;
+  color: #ccc;
+  padding: 0;
+  align-self: center;
+  font-size: .9em;
+  width: 4ch;
+}
+
+// for dtp__ampm-am/pm add only left right and top/bottom border raidus
+.dtp__ampm-am {
+  border: 1px solid var(--accent-color);
+  border-top-left-radius: .75ch;
+  border-top-right-radius: .75ch;
+  border-bottom: none
+}
+
+.dtp__ampm-pm {
+  border: 1px solid var(--accent-color);
+  border-bottom-left-radius: .75ch;
+  border-bottom-right-radius: .75ch;
+  border-top: none
+}
+
+@media (max-width: 350px) { 
+  .dtp__ampm {
+    grid-template-columns: 0fr 0fr;
+    grid-template-rows: 0fr;
+    margin-bottom: 0.5em;
+  }
+  
+  .dtp__ampm-am {
+    border: 1px solid var(--accent-color);
+    border-radius: 0;
+    border-top-left-radius: .75ch;
+    border-bottom-left-radius: .75ch;
+    border-right: none;
+  }
+  
+  .dtp__ampm-pm {
+    border: 1px solid var(--accent-color);
+    border-radius: 0;
+    border-top-right-radius: .75ch;
+    border-bottom-right-radius: .75ch;
+    border-left: none;
+  }
+  
+}
+
+.dtp__ampm-active {
+  color: var(--accent-color);
+  background-color: #0e0552;
+}
+
+/* Chrome, Safari, Edge, Opera */
+.dtp__container input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+/* Firefox */
+.dtp__container  input[type=number] {
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+
+input#dtp__year {
+  width: 4ch;
+}
+
+input.dtp__time_part {
+  width: 2.5ch;
+}
+
+</style>

--- a/src/components/TapToInput.vue
+++ b/src/components/TapToInput.vue
@@ -1,0 +1,173 @@
+<!-- Input/Display with up down arrow above and below -->
+<template>
+    <span 
+      v-if="!editing || !props.editable"
+      @click="editing = !editing"
+      ref="display"
+      class="tti__display"
+      >{{ pad(pseudoValue) }}
+    </span>
+    <input 
+      v-else
+      type="number" 
+      :min="minValue"
+      :max="maxValue"
+      :step="stepValue"
+      :value="pseudoValue" 
+      @change="setValue"
+      @blur="blurred"
+      ref="input"
+      class="tti__input"
+      />
+</template>
+
+<script setup lang="ts">
+import { ref, watch, computed } from 'vue';
+import type { TapToInputProps } from "../types";
+
+const editing = ref(false);
+const input = ref();
+
+const props = withDefaults(defineProps<TapToInputProps>(), {
+  editable: true,
+  min: 0,
+  max: 9999,
+  step: 1,
+  clamp: false,
+  zeroPadLength: 0,
+});
+
+const emit = defineEmits<{
+  (event: "update:modelValue", value: number): void
+}>();
+
+const pseudoValue = ref(props.modelValue);
+
+function pad(value: number) {
+  if (props.zeroPadLength > 0) {
+    return value.toString().padStart(props.zeroPadLength, '0');
+  }
+  return value;
+}
+
+const parseValue = (value: string | number | CallableFunction) => {
+  if (typeof value === 'number') {
+    return value;
+  } 
+  if (typeof value === 'function') {
+    return value();
+  }
+  return value.includes('.') ? parseFloat(value) : parseInt(value);
+};
+
+const minValue = ref(parseValue(props.min));
+const maxValue = ref(parseValue(props.max));
+const stepValue = ref(parseValue(props.step));
+
+function setValue(event: Event) {
+  if (event.target) {
+    pseudoValue.value = parseInt((event.target as HTMLInputElement).value);
+  }
+}
+
+function blurred() {
+  editing.value = false;
+}
+
+function round(value: number, toNearest: number): number {
+  return Math.round(value / toNearest) * toNearest;
+}
+
+const isValid = computed(() => {
+  if (pseudoValue.value < minValue.value) {
+    return false;
+  }
+  if (pseudoValue.value > maxValue.value) {
+    return false;
+  }
+  return true;
+});
+
+function clampValue(value: number) {
+  if (!props.clamp) {
+    return value;
+  }
+  if (value < minValue.value) {
+    value = minValue.value;
+  } else if (value > maxValue.value) {
+    value = maxValue.value;
+  }
+  if ((value % stepValue.value) !== 0) {
+    value = round(value, stepValue.value);
+  }
+  return value;
+}
+
+// Watchers
+watch(() => props.min, (newVal) => {
+  minValue.value = parseValue(newVal);
+  pseudoValue.value = clampValue(pseudoValue.value);
+});
+
+watch(() => props.max, (newVal) => {
+  maxValue.value = parseValue(newVal);
+  pseudoValue.value = clampValue(pseudoValue.value);
+});
+
+watch(() => props.step, (newVal) => {
+  stepValue.value = parseValue(newVal);
+});
+
+watch(() => props.modelValue, (newVal) => {
+  pseudoValue.value = clampValue(newVal);
+});
+
+watch(input, (value) => {
+  if (value) {
+    value.focus();
+  }    
+});
+
+watch(pseudoValue, (newValue, oldValue) => {
+  if (isValid.value) {
+    emit("update:modelValue", pseudoValue.value);
+    return;
+  }
+  if (props.clamp) {
+    pseudoValue.value = clampValue(newValue);
+    emit("update:modelValue", pseudoValue.value);
+    return;
+  }
+  pseudoValue.value = oldValue;
+});
+
+</script>
+
+<style>
+/* Chrome, Safari, Edge, Opera */
+input.tti__input::-webkit-outer-spin-button,
+input.tti__input::-webkit-inner-spin-button
+{
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+/* Firefox */
+input.tti__input[type='number']
+{
+  -moz-appearance: textfield;
+  -webkit-appearance: textfield;
+  appearance: textfield;
+}
+
+input.tti__input[type='number']
+{
+  text-align: center;
+}
+
+input.tti__input[type='number']:invalid
+{
+  background-color: #fd6969;
+}
+
+</style>

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { useWindowShape, WindowShape } from "./composables/windowShape";
 import { useWWTKeyboardControls } from "./composables/wwtKeyboard";
 
 import CreditLogos from "./components/CreditLogos.vue";
+import DateTimePicker from "./components/DateTimePicker.vue";
 import FundingAcknowledgement from "./components/FundingAcknowledgement.vue";
 import Gallery from "./components/Gallery.vue";
 import GeolocationButton from "./components/GeolocationButton.vue";
@@ -34,6 +35,7 @@ export {
   useWWTKeyboardControls,
 
   CreditLogos,
+  DateTimePicker,
   FundingAcknowledgement,
   Gallery,
   GeolocationButton,

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import LocationSearch from "./components/LocationSearch.vue";
 import LocationSelector from "./components/LocationSelector.vue";
 import PlaybackControl from "./components/PlaybackControl.vue";
 import SpeedControl from "./components/SpeedControl.vue";
+import TapToInput from "./components/TapToInput.vue";
 import WwtHud from "./components/WwtHud.vue";
 
 export {
@@ -44,6 +45,7 @@ export {
   LocationSelector,
   PlaybackControl,
   SpeedControl,
+  TapToInput,
   WwtHud,
 };
 

--- a/src/stories/DateTimePicker.stories.ts
+++ b/src/stories/DateTimePicker.stories.ts
@@ -35,7 +35,6 @@ export const Primary: Story = {
     };
   },
   args: {
-    modelValue: new Date(),
     debug: false,
     useAmPm: true,
     editableTime: true,

--- a/src/stories/DateTimePicker.stories.ts
+++ b/src/stories/DateTimePicker.stories.ts
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+import { Meta, StoryObj } from "@storybook/vue3";
+import { DateTimePickerProps } from "../types";
+import { DateTimePicker } from "..";
+import { ref } from "vue";
+
+const meta: Meta<typeof DateTimePicker> = {
+  component: DateTimePicker,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof DateTimePicker>;
+
+export const Primary: Story = {
+  render: (args: DateTimePickerProps) => {
+
+    const date = ref(new Date());
+    return {
+      components: { DateTimePicker },
+      template: `
+        <div style="width: 900px; height: 400px">
+          <DateTimePicker
+            v-bind="args"
+            v-model="date"
+          />
+          <hr style="margin: 30px">
+          <div>The currently selected time is <span id="current-datetime">{{ date.toLocaleString() }}</span></div>
+        </div>
+      `,
+      setup() {
+        return { args, date };
+      }
+    };
+  },
+  args: {
+    modelValue: new Date(),
+    debug: false,
+    useAmPm: true,
+    editableTime: true,
+  }
+};

--- a/src/stories/LocationSearch.stories.ts
+++ b/src/stories/LocationSearch.stories.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
 import { Meta, StoryObj } from "@storybook/vue3";
+import { ref } from "vue";
 import { LocationSearchProps, LocationSearch, geocodingInfoForSearch, textForMapboxFeature } from "..";
 
 import "./stories.css";
@@ -16,12 +17,14 @@ type Story = StoryObj<typeof LocationSearch>;
 export const Primary: Story = {
   render: (args: LocationSearchProps) => {
 
+    const open = ref(true);
     return {
       components: { LocationSearch },
       template: `
         <div style="width: 900px; height: 400px">
           <LocationSearch
             v-bind="args"
+            v-model="open"
             @set-location="(loc) => {
               $el.querySelector('#selected-location').innerHTML = textForMapboxFeature(loc);
             }"
@@ -31,13 +34,12 @@ export const Primary: Story = {
         </div>
       `,
       setup() {
-        return { args, textForMapboxFeature };
+        return { args, open, textForMapboxFeature };
       }
     };
   },
   args: {
     searchProvider: (searchText: string) => geocodingInfoForSearch(searchText, { access_token: process.env.VUE_APP_MAPBOX_ACCESS_TOKEN ?? "" }),
-    modelValue: true,
     stayOpen: true,
     accentColor: "orange",
     bgColor: "black",

--- a/src/types.ts
+++ b/src/types.ts
@@ -354,3 +354,14 @@ export interface TapToInputProps {
   /** What the (minimum) padded length of the value string should be after front-padding with zeros */
   zeroPadLength?: number;
 }
+
+export interface DateTimePickerProps {
+  /** The current datetime value */
+  modelValue: Date;
+  /** Whether to show debugging information */
+  debug?: boolean;
+  /** Whether to use AM/PM (as opposed ot 24-hour time) */
+  useAmPm?: boolean;
+  /** Whether or not the time is editable */
+  editableTime?: boolean;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -358,6 +358,8 @@ export interface TapToInputProps {
 export interface DateTimePickerProps {
   /** The current datetime value */
   modelValue: Date;
+  /** The accent color for the component. Should be a valid CSS color */
+  accentColor?: string;
   /** Whether to show debugging information */
   debug?: boolean;
   /** Whether to use AM/PM (as opposed ot 24-hour time) */

--- a/src/types.ts
+++ b/src/types.ts
@@ -337,3 +337,20 @@ export interface LocationSearchProps {
   /** The background color of the search box. Should be a valid CSS color */
   bgColor?: string;
 }
+
+export interface TapToInputProps {
+  /** The current value of the input */
+  modelValue: number;
+  /** Whether the input should be editable */
+  editable?: boolean;
+  /** The minimum allowed value */
+  min?: string | number;
+  /** The maximum allowed value */
+  max?: string | number;
+  /** The increment between allowed values */
+  step?: number;
+  /** Whether or not to clamp values between the min and max */
+  clamp?: boolean;
+  /** What the (minimum) padded length of the value string should be after front-padding with zeros */
+  zeroPadLength?: number;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -362,6 +362,6 @@ export interface DateTimePickerProps {
   debug?: boolean;
   /** Whether to use AM/PM (as opposed ot 24-hour time) */
   useAmPm?: boolean;
-  /** Whether or not the time is editable */
+  /** Whether or not the time is editable via text boxes */
   editableTime?: boolean;
 }


### PR DESCRIPTION
This PR resolves #26 by adding the date/time picker component to the toolkit. Per usual, I've added a basic story for this component - in addition to the standard controls for adjusting props, it has the same setup as the location search story, where we have a span whose text gets updated on a v-model change.