### PR TITLE
Share button

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@fortawesome/vue-fontawesome": "^3.0.6",
     "@kyvg/vue3-notification": "^2.9.1",
     "@mdi/font": "^7.4.47",
-    "@vueuse/components": "^13.1.0",
+    "@vueuse/core": "^13.1.0",
     "@wwtelescope/engine-pinia": "^0.9.0",
     "leaflet": "^1.9.4",
     "pinia": "~2.1.7",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@fortawesome/vue-fontawesome": "^3.0.6",
     "@kyvg/vue3-notification": "^2.9.1",
     "@mdi/font": "^7.4.47",
+    "@vueuse/components": "^13.1.0",
     "@wwtelescope/engine-pinia": "^0.9.0",
     "leaflet": "^1.9.4",
     "pinia": "~2.1.7",

--- a/src/components/ShareButton.vue
+++ b/src/components/ShareButton.vue
@@ -4,7 +4,7 @@
     <template v-slot:activator="{ props }">
       <v-btn
         :id="id"
-        aria-label="Get link to share selected view"
+        :aria-label="ariaLabel"
         class="share-button"
         icon
         @click="share"
@@ -56,6 +56,7 @@ const props = withDefaults(defineProps<ShareButtonProps>(), {
   tooltipText: "Share selected view",
   alert: false,
   alertText: "Share link copied to clipboard. Paste to share this view!",
+  ariaLabel: "Get link to share selected view",
 });
 
 const emit = defineEmits<{

--- a/src/components/ShareButton.vue
+++ b/src/components/ShareButton.vue
@@ -1,7 +1,7 @@
 <template>
 
   <v-tooltip :disabled="!tooltip" :text="tooltipText">
-    <template v-slot:activator="{ props }">
+    <template v-slot:activator="{ props }: { props: Record<string,any> }">
       <v-btn
         :id="id"
         :aria-label="ariaLabel"

--- a/src/components/ShareButton.vue
+++ b/src/components/ShareButton.vue
@@ -1,55 +1,48 @@
-
 <template>
-  <use-clipboard v-slot="{ copy }" :source="source">
-    <v-snackbar 
-      v-if="tooltipDisabled || alert"
-      class="share-button-snackbar"   
-      timeout="3500" 
-      location="top" 
-      activator="#share-button"
-      text="Share link copied to clipboard. Paste to share this view!"
-      color="success"
-      variant="flat"
-      min-height="0px"
-      min-width="0px"
-      transition="slide-y-transition"
-      close-on-content-click
-      >
-    </v-snackbar>
-    <v-tooltip :disabled="tooltipDisabled" text="Share selected view">
-      <template v-slot:activator="{ props }">
-        <v-btn
-          id="share-button"
-          aria-label="Get link to share selected view"
-          class="share-button"
-          icon
-          @click="() => {
-            copy(source);
-            $emit('share');
-          }
-          "
-          @keyup.enter="() => {
-            copy(source);
-            $emit('share');
-          }"
-          v-bind="props"
-          :color="buttonColor"
-          :elevation="elevation"
-          :size="size"
-          :rounded="rounded"
-        > 
-          <v-icon :color="iconColor">mdi-share-variant</v-icon>
-        </v-btn>
-      </template>
-    </v-tooltip>
-  </use-clipboard>
+
+  <v-tooltip :disabled="tooltipDisabled" text="Share selected view">
+    <template v-slot:activator="{ props }">
+      <v-btn
+        id="share-button"
+        aria-label="Get link to share selected view"
+        class="share-button"
+        icon
+        @click="share"
+        @keyup.enter="share"
+        v-bind="props"
+        :color="buttonColor"
+        :elevation="elevation"
+        :size="size"
+        :rounded="rounded"
+      > 
+        <v-icon :color="iconColor">mdi-share-variant</v-icon>
+      </v-btn>
+      <v-snackbar 
+        v-if="tooltipDisabled || alert"
+        class="share-button-snackbar"   
+        timeout="3500" 
+        location="top" 
+        activator="#share-button"
+        text="Share link copied to clipboard. Paste to share this view!"
+        color="success"
+        variant="flat"
+        min-height="0px"
+        min-width="0px"
+        transition="slide-y-transition"
+        close-on-content-click
+        >
+      </v-snackbar>
+    </template>
+  </v-tooltip>
 </template>
 
 <script setup lang="ts">
+import { useClipboard } from "@vueuse/core";
+const { copy } = useClipboard();
 import { type ShareButtonProps } from "../types";
-import { UseClipboard } from "@vueuse/components";
 
 const props = withDefaults(defineProps<ShareButtonProps>(), {
+  source: () => window.location.href,
   buttonColor: "#ffffff66",
   iconColor: "#333",
   elevation: "0",
@@ -58,4 +51,34 @@ const props = withDefaults(defineProps<ShareButtonProps>(), {
   tooltipDisabled: false,
   alert: false,
 });
+
+const emit = defineEmits<{
+  "share": [activate?: null],
+}>();
+
+function getURL() {
+  if (typeof props.source === "string") {
+    return props.source;
+  }
+  return props.source ? props.source() : window.location.href;
+}
+
+function share() {
+  copy(getURL());
+  emit("share");
+}
 </script>
+
+<style lang="less">
+.share-button {
+  z-index: 1000;
+  padding-inline: 5px;
+  border-radius: 8px !important;
+  border: thin solid var(--accent-color-2) !important;
+
+  & .v-snackbar__wrapper > .v-snackbar__content {
+    padding: 0.75em 1em;
+  }
+}
+
+</style>

--- a/src/components/ShareButton.vue
+++ b/src/components/ShareButton.vue
@@ -1,9 +1,9 @@
 <template>
 
-  <v-tooltip :disabled="tooltipDisabled" text="Share selected view">
+  <v-tooltip :disabled="!tooltip" :text="tooltipText">
     <template v-slot:activator="{ props }">
       <v-btn
-        id="share-button"
+        :id="id"
         aria-label="Get link to share selected view"
         class="share-button"
         icon
@@ -18,12 +18,12 @@
         <v-icon :color="iconColor">mdi-share-variant</v-icon>
       </v-btn>
       <v-snackbar 
-        v-if="tooltipDisabled || alert"
+        v-if="!tooltip || alert"
         class="share-button-snackbar"   
         timeout="3500" 
         location="top" 
-        activator="#share-button"
-        text="Share link copied to clipboard. Paste to share this view!"
+        :activator="`#${id}`"
+        :text="alertText"
         color="success"
         variant="flat"
         min-height="0px"
@@ -37,9 +37,13 @@
 </template>
 
 <script setup lang="ts">
+import { ref } from "vue";
 import { useClipboard } from "@vueuse/core";
 const { copy } = useClipboard();
-import { type ShareButtonProps } from "../types";
+import { v4 } from "uuid";
+import type { ShareButtonProps } from "../types";
+
+const id = ref(`share-button-${v4()}`);
 
 const props = withDefaults(defineProps<ShareButtonProps>(), {
   source: () => window.location.href,
@@ -48,8 +52,10 @@ const props = withDefaults(defineProps<ShareButtonProps>(), {
   elevation: "0",
   size: "small",
   rounded: "1",
-  tooltipDisabled: false,
+  tooltip: true,
+  tooltipText: "Share selected view",
   alert: false,
+  alertText: "Share link copied to clipboard. Paste to share this view!",
 });
 
 const emit = defineEmits<{

--- a/src/components/ShareButton.vue
+++ b/src/components/ShareButton.vue
@@ -1,0 +1,61 @@
+
+<template>
+  <use-clipboard v-slot="{ copy }" :source="source">
+    <v-snackbar 
+      v-if="tooltipDisabled || alert"
+      class="share-button-snackbar"   
+      timeout="3500" 
+      location="top" 
+      activator="#share-button"
+      text="Share link copied to clipboard. Paste to share this view!"
+      color="success"
+      variant="flat"
+      min-height="0px"
+      min-width="0px"
+      transition="slide-y-transition"
+      close-on-content-click
+      >
+    </v-snackbar>
+    <v-tooltip :disabled="tooltipDisabled" text="Share selected view">
+      <template v-slot:activator="{ props }">
+        <v-btn
+          id="share-button"
+          aria-label="Get link to share selected view"
+          class="share-button"
+          icon
+          @click="() => {
+            copy(source);
+            $emit('share');
+          }
+          "
+          @keyup.enter="() => {
+            copy(source);
+            $emit('share');
+          }"
+          v-bind="props"
+          :color="buttonColor"
+          :elevation="elevation"
+          :size="size"
+          :rounded="rounded"
+        > 
+          <v-icon :color="iconColor">mdi-share-variant</v-icon>
+        </v-btn>
+      </template>
+    </v-tooltip>
+  </use-clipboard>
+</template>
+
+<script setup lang="ts">
+import { type ShareButtonProps } from "../types";
+import { UseClipboard } from "@vueuse/components";
+
+const props = withDefaults(defineProps<ShareButtonProps>(), {
+  buttonColor: "#ffffff66",
+  iconColor: "#333",
+  elevation: "0",
+  size: "small",
+  rounded: "1",
+  tooltipDisabled: false,
+  alert: false,
+});
+</script>

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import IconButton from "./components/IconButton.vue";
 import LocationSearch from "./components/LocationSearch.vue";
 import LocationSelector from "./components/LocationSelector.vue";
 import PlaybackControl from "./components/PlaybackControl.vue";
+import ShareButton from "./components/ShareButton.vue";
 import SpeedControl from "./components/SpeedControl.vue";
 import TapToInput from "./components/TapToInput.vue";
 import WwtHud from "./components/WwtHud.vue";
@@ -44,6 +45,7 @@ export {
   LocationSearch,
   LocationSelector,
   PlaybackControl,
+  ShareButton,
   SpeedControl,
   TapToInput,
   WwtHud,

--- a/src/stories/ShareButton.stories.ts
+++ b/src/stories/ShareButton.stories.ts
@@ -27,7 +27,9 @@ export const Primary: Story = {
     elevation: "0",
     size: "small",
     rounded: "1",
-    tooltipDisabled: false,
+    tooltip: true,
+    tooltipText: "Share selected view",
     alert: false,
+    alertText: "Share link copied to clipboard. Paste to share this view!",
   }
 };

--- a/src/stories/ShareButton.stories.ts
+++ b/src/stories/ShareButton.stories.ts
@@ -31,5 +31,6 @@ export const Primary: Story = {
     tooltipText: "Share selected view",
     alert: false,
     alertText: "Share link copied to clipboard. Paste to share this view!",
+    ariaLabel: "Get link to share selected view",
   }
 };

--- a/src/stories/ShareButton.stories.ts
+++ b/src/stories/ShareButton.stories.ts
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+import { Meta, StoryObj } from "@storybook/vue3";
+import { ShareButton, ShareButtonProps } from "..";
+
+const meta: Meta<typeof ShareButton> = {
+  component: ShareButton,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof ShareButton>;
+
+export const Primary: Story = {
+  render: (args: ShareButtonProps) => ({
+    components: { ShareButton },
+    template: `<ShareButton v-bind="args" />`,
+    setup() {
+      return { args };
+    }
+  }),
+  args: {
+    // In Storybook, the component is inside an iframe
+    source: () => (top ?? window).location.href,
+    buttonColor: "#ffffff66",
+    iconColor: "#333",
+    elevation: "0",
+    size: "small",
+    rounded: "1",
+    tooltipDisabled: false,
+    alert: false,
+  }
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -375,6 +375,8 @@ export interface ShareButtonProps {
   elevation?: string | number;
   size?: string;
   rounded?: string | number;
-  tooltipDisabled?: boolean;
+  tooltip?: boolean;
+  tooltipText?: string;
   alert?: boolean;
+  alertText?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -369,14 +369,26 @@ export interface DateTimePickerProps {
 }
 
 export interface ShareButtonProps {
+  /** A string, or a function producing a string, that gives the text to be copied */
   source?: (() => string) | string;
+  /** The color of the button. Should be a valid CSS color */
   buttonColor?: string;
+  /** The color of the share icon. Should be a valid CSS color */
   iconColor?: string;
+  /** The elevatio of the button */ 
   elevation?: string | number;
+  /** The size of the button. Can be a number (in px), a CSS size, or a predefined Vuetify size */
   size?: string;
+  /** The border radius of the button. Can be 0, xs, sm, true, lg, xl, pill, circle, shaped. These come from Vuetify */
   rounded?: string | number;
+  /** Whether to show a tooltip on hover */
   tooltip?: boolean;
+  /** The text of the tooltip */
   tooltipText?: string;
+  /** Whether to show a snackbar alert when the button is pressed */
   alert?: boolean;
+  /** The text of the snackbar alert */
   alertText?: string;
+  /** The ARIA label for the button */
+  ariaLabel?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -369,7 +369,7 @@ export interface DateTimePickerProps {
 }
 
 export interface ShareButtonProps {
-  source: string;
+  source?: (() => string) | string;
   buttonColor?: string;
   iconColor?: string;
   elevation?: string | number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -367,3 +367,14 @@ export interface DateTimePickerProps {
   /** Whether or not the time is editable via text boxes */
   editableTime?: boolean;
 }
+
+export interface ShareButtonProps {
+  source: string;
+  buttonColor?: string;
+  iconColor?: string;
+  elevation?: string | number;
+  size?: string;
+  rounded?: string | number;
+  tooltipDisabled?: boolean;
+  alert?: boolean;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -518,6 +518,7 @@ __metadata:
     "@vue/cli-service": ^5.0.8
     "@vue/compiler-sfc": ^3.4.25
     "@vue/eslint-config-typescript": ^12.0.0
+    "@vueuse/components": ^13.1.0
     "@wwtelescope/engine-pinia": ^0.9.0
     copy-webpack-plugin: ^12.0.2
     css-loader: ^7.1.1
@@ -2002,6 +2003,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/web-bluetooth@npm:^0.0.21":
+  version: 0.0.21
+  resolution: "@types/web-bluetooth@npm:0.0.21"
+  checksum: 85a957d52263607d26236b1748771fdcfc0791f2c20373370e6c725410067dee6a5ec425b0e25ec85db2908dd59415079070655fd3277841cbbd3a557d1f7777
+  languageName: node
+  linkType: hard
+
 "@types/webpack-env@npm:^1.15.2":
   version: 1.18.8
   resolution: "@types/webpack-env@npm:1.18.8"
@@ -2621,6 +2629,47 @@ __metadata:
   version: 1.3.0
   resolution: "@vue/web-component-wrapper@npm:1.3.0"
   checksum: 8cc4d1135990e61ab9d38a7b6460b018703b38b4dd3477390083018bffb93b283fabb7d57d83b3cfb78dd44da4f863167b964fe88dfa9886a54996f308036a94
+  languageName: node
+  linkType: hard
+
+"@vueuse/components@npm:^13.1.0":
+  version: 13.1.0
+  resolution: "@vueuse/components@npm:13.1.0"
+  dependencies:
+    "@vueuse/core": 13.1.0
+    "@vueuse/shared": 13.1.0
+  peerDependencies:
+    vue: ^3.5.0
+  checksum: 1374766d4b92ade6663b49721a72acd3dc7687aa590038ae2a7eb4ab5f0118e8cb77ef1e36a80f6ebdce14e1bf43a1c48baf69abdee5b76dc14afbbabeaa3bbf
+  languageName: node
+  linkType: hard
+
+"@vueuse/core@npm:13.1.0":
+  version: 13.1.0
+  resolution: "@vueuse/core@npm:13.1.0"
+  dependencies:
+    "@types/web-bluetooth": ^0.0.21
+    "@vueuse/metadata": 13.1.0
+    "@vueuse/shared": 13.1.0
+  peerDependencies:
+    vue: ^3.5.0
+  checksum: 94323f644be9c6b8d235c085806090a9f88567b43893d55189b358ed2754c957e7d6ef31128785c67c07bf4bea99d6395704e5da56e95b271a5d2ac366481f83
+  languageName: node
+  linkType: hard
+
+"@vueuse/metadata@npm:13.1.0":
+  version: 13.1.0
+  resolution: "@vueuse/metadata@npm:13.1.0"
+  checksum: 2e319241aab2a381fc46bf9ea576389f34ec157a51d4df52e20ff63e746f65b56a66dc1756aac31b4e10150403933b7cf65da1ad143ff46d173bff369ccbfc71
+  languageName: node
+  linkType: hard
+
+"@vueuse/shared@npm:13.1.0":
+  version: 13.1.0
+  resolution: "@vueuse/shared@npm:13.1.0"
+  peerDependencies:
+    vue: ^3.5.0
+  checksum: 7d3dcd3a4545b5a583a3a1e9d4991138e1830cd39ccc9301b22d348ad3902574883355b217a63a28f3ca7f47ad925d882b598e643a67522c63544b5c1daa8835
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -518,7 +518,7 @@ __metadata:
     "@vue/cli-service": ^5.0.8
     "@vue/compiler-sfc": ^3.4.25
     "@vue/eslint-config-typescript": ^12.0.0
-    "@vueuse/components": ^13.1.0
+    "@vueuse/core": ^13.1.0
     "@wwtelescope/engine-pinia": ^0.9.0
     copy-webpack-plugin: ^12.0.2
     css-loader: ^7.1.1
@@ -2632,19 +2632,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vueuse/components@npm:^13.1.0":
-  version: 13.1.0
-  resolution: "@vueuse/components@npm:13.1.0"
-  dependencies:
-    "@vueuse/core": 13.1.0
-    "@vueuse/shared": 13.1.0
-  peerDependencies:
-    vue: ^3.5.0
-  checksum: 1374766d4b92ade6663b49721a72acd3dc7687aa590038ae2a7eb4ab5f0118e8cb77ef1e36a80f6ebdce14e1bf43a1c48baf69abdee5b76dc14afbbabeaa3bbf
-  languageName: node
-  linkType: hard
-
-"@vueuse/core@npm:13.1.0":
+"@vueuse/core@npm:^13.1.0":
   version: 13.1.0
   resolution: "@vueuse/core@npm:13.1.0"
   dependencies:


### PR DESCRIPTION
I really like the share button component that @johnarban and @patudom created in the TEMPO Lite data story, and figured that sharing via a URL is a common enough operation that we should have an out-of-the-box component for it. This PR adds a component that is largely the same as the one in the TEMPO Lite story, with a couple of changes:
* I converted over to Composition API to match the rest of the toolkit
* I tweaked the way that this handles copying to the clipboard a bit. Rather than use a component, we now use the `useClipboard` composable from VueUse, We also now don't pass the `source` prop as a ref into the clipboard, instead getting the text from a function that is invoked when the button is activated. The reason for this is so that we can pass in a function that provides a string as a prop to use as the clipboard text. The main use case that I'm thinking of here is some sort of state-based manipulation of the current URL - maybe sometimes you want to copy query parameters, maybe sometimes you don't, etc. Passing in a string is of course still supported. If you don't pass any `source`, the default value is a function that returns `window.location.href` (a function so that the value can be live, as the href isn't a reactive).

I also added the ability to modify the tooltip/alert text/ARIA label via props, just to add a bit more flexibility. Any suggestions are welcome!

Thoughts for the future: It would be nice to see if Capacitor has any hooks for sharing using mobile-specific methods - e.g. via an `Intent` on Android. If so, we could hook the share button functionality up to that instead on a mobile device.