### PR TITLE
Updates to credit logos component

### DIFF
--- a/src/components/CreditLogos.vue
+++ b/src/components/CreditLogos.vue
@@ -4,10 +4,11 @@
       <a
         v-for="logo in logos"
         v-bind:key="logo.href"
+        :id="logo.name ? logo.name : undefined"
         :href="logo.href"
         target="_blank"
         rel="noopener noreferrer"
-        class="logo-link"
+        :class="['logo-link', logo.name ? `logo-${logo.name}` : '']"
       >
         <img
           :alt="logo.alt"
@@ -25,24 +26,28 @@ import { CreditLogo, CreditLogosProps, DefaultCreditLogo } from "../types";
 
 const DEFAULT_LOGOS: Map<DefaultCreditLogo, CreditLogo> = new Map([
   ["cosmicds", {
-    src: "https://raw.githubusercontent.com/cosmicds/minids/main/assets/cosmicds_logo_for_dark_backgrounds.png",
+    src: "https://projects.cosmicds.cfa.harvard.edu/cds-website/logos/cosmicds_logo_for_dark_backgrounds.png",
     href: "https://www.cosmicds.cfa.harvard.edu/",
     alt: "CosmicDS Logo",
+    name: "cosmicds",
   }],
   ["wwt", {
-    src: "https://raw.githubusercontent.com/cosmicds/minids/main/assets/logo_wwt.png",
+    src: "https://projects.cosmicds.cfa.harvard.edu/cds-website/logos/logo_wwt.png",
     href: "https://worldwidetelescope.org/home/",
     alt: "WWT Logo",
+    name: "wwt",
   }],
   ["sciact", {
-    src: "https://raw.githubusercontent.com/cosmicds/minids/main/assets/logo_sciact.png",
+    src: "https://projects.cosmicds.cfa.harvard.edu/cds-website/logos/logo_sciact.png",
     href: "https://science.nasa.gov/learners",
     alt: "SciAct Logo",
+    name: "sciact",
   }],
   ["nasa", {
-    src: "https://raw.githubusercontent.com/cosmicds/minids/main/assets/NASA_Grantee_color_no_outline.png",
+    src: "https://projects.cosmicds.cfa.harvard.edu/cds-website/logos/NASA_Grantee_color_no_outline.png",
     href: "https://nasa.gov/",
-    alt: "NASA Grantee Logo"
+    alt: "NASA Grantee Logo",
+    name: "nasa",
   }]
 ]);
 
@@ -70,9 +75,11 @@ const cssVars = computed(() => {
 
   img {
     height: var(--logo-size);
+    width: auto;
     margin-inline: 0.1em;
   }
 }
+
 .logo-link {
   display: inline-flex;
 }

--- a/src/components/CreditLogos.vue
+++ b/src/components/CreditLogos.vue
@@ -40,9 +40,9 @@ const DEFAULT_LOGOS: Map<DefaultCreditLogo, CreditLogo> = new Map([
     alt: "SciAct Logo",
   }],
   ["nasa", {
-    src: "https://raw.githubusercontent.com/cosmicds/minids/main/assets/NASA_Partner_color_300_no_outline.png",
+    src: "https://raw.githubusercontent.com/cosmicds/minids/main/assets/NASA_Grantee_color_no_outline.png",
     href: "https://nasa.gov/",
-    alt: "NASA Partner Logo"
+    alt: "NASA Grantee Logo"
   }]
 ]);
 

--- a/src/stories/CreditLogos.stories.ts
+++ b/src/stories/CreditLogos.stories.ts
@@ -25,7 +25,8 @@ export const Primary: Story = {
       {
         alt: "Smithsonian Logo",
         src: "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/Smithsonian_sun_logo_no_text.svg/1024px-Smithsonian_sun_logo_no_text.svg.png",
-        href: "https://www.si.edu/"
+        href: "https://www.si.edu/",
+        name: "smithsonian",
       }
     ],
     defaultLogos: ["wwt", "cosmicds", "nasa", "sciact"],

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,8 @@ export interface CreditLogo {
   href: string;
   /** Alt text to use for the logo. If none is given, the logo will have no alt text */
   alt?: string;
+  /** A name to use for the logo. If provided, the logo is given a class of `logo-${name}` to allow CSS targeting */
+  name?: string;
 }
 
 /** A union type enumerating the default credit logos */


### PR DESCRIPTION
This PR makes two changes to the credit logos component:
* Update the default NASA logo to be the NASA Grantee logo
* Allow optionally adding a `name` field to a `CreditLogo` instance. If given, the logo will get a `logo-<name>` class to allow targeting via CSS

My only concern here is that the NASA Grantee logo is too small - it's set to the same size as the other logos, but as it has the image itself has both the logo and the text, the logo itself is a bit small (see the screenshot below):
<img width="257" alt="Screenshot 2025-05-02 at 9 48 50 AM" src="https://github.com/user-attachments/assets/af1fa5d5-f114-4c1d-b8bc-98932bdf12bf" />

But, the logo isn't particularly large on the current version either:
<img width="241" alt="Screenshot 2025-05-02 at 9 49 35 AM" src="https://github.com/user-attachments/assets/93eb715a-1d91-4f51-bcf4-148e6e9ffdb7" />

