### PR TITLE
Add docstrings for events and slots

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,7 +1,7 @@
 import type { StorybookConfig } from "@storybook/vue3-webpack5";
 
 const config: StorybookConfig = {
-  stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
+  stories: ["../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
   addons: [
     "@storybook/addon-webpack5-compiler-swc",
     "@storybook/addon-links",

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,5 +1,12 @@
 import type { StorybookConfig } from "@storybook/vue3-webpack5";
 
+const vueOptions: StorybookConfig["framework"] = {
+  name: "@storybook/vue3-webpack5",
+  options: {
+    docgen: "vue-component-meta",
+  }
+}
+
 const config: StorybookConfig = {
   stories: ["../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
   addons: [
@@ -10,10 +17,7 @@ const config: StorybookConfig = {
     "@storybook/addon-interactions",
     "storybook-dark-mode",
   ],
-  framework: {
-    name: "@storybook/vue3-webpack5",
-    options: {},
-  },
+  framework: vueOptions,
   docs: {
     autodocs: "tag",
   },

--- a/src/components/DateTimePicker.vue
+++ b/src/components/DateTimePicker.vue
@@ -40,7 +40,7 @@
         <!-- 2-4 -->
         <span>-</span>
         <!-- 3-4 -->
-        <slot name="bottom-middle"><span></span></slot>
+        <slot name="bottom"><span></span></slot>
 
         <!-- 1-5 -->
         <button id="dtp__day-up" class="dtp__grid-item" @click="increment('day')">
@@ -55,9 +55,9 @@
         </button>
 
         <!-- 1-6 -->
-        <slot name="top-middle"><span></span></slot>
+        <slot name="top"><span></span></slot>
         <!-- 2-6 -->
-        <span class="dtp__middle-slot"><slot name="center-middle"></slot></span>
+        <span class="dtp__middle-slot"><slot name="center"></slot></span>
         <!-- 3-6 -->
         <span></span>
 
@@ -172,11 +172,16 @@ const emit = defineEmits<{
   (event: "update:modelValue", datetime: Date): void
 }>();
 
+// TODO: Make these descriptions better
 defineSlots<{
+  /** A slot for adding additional content below the datetime picker. */
   default(): VNode[];
-  topMiddle(): VNode[];
-  centerMiddle(): VNode[];
-  bottomMiddle(): VNode[];
+  /** A slot for adding additional content at the top-middle of the picker */
+  top(): VNode[];
+  /** A slot for adding additional content at the center-middle of the picker */
+  center(): VNode[];
+  /** A slot for adding additional content at the bottom-middle of the picker */
+  bottom(): VNode[];
 }>();
 
 const year = ref(props.modelValue.getFullYear());
@@ -216,7 +221,6 @@ const values = {
   second: second,
 };
 
-type Unit = 'year' | 'month' | 'day' | 'hour' | 'minute' | 'second';
 
 const limits = computed(() => ({
   year: { min: 1, max: Infinity },
@@ -227,7 +231,8 @@ const limits = computed(() => ({
   second: { min: 0, max: 59 },
 }));
 
-const units: Unit[] = ['second', 'minute', 'hour', 'day', 'month', 'year'];
+const units  = ['second', 'minute', 'hour', 'day', 'month', 'year'] as const;
+type Unit = typeof units[number];
 
 function changeValue(unit: Unit, increment: boolean) {
   const limit = limits.value[unit].max;

--- a/src/components/DateTimePicker.vue
+++ b/src/components/DateTimePicker.vue
@@ -231,8 +231,17 @@ const limits = computed(() => ({
   second: { min: 0, max: 59 },
 }));
 
-const units  = ['second', 'minute', 'hour', 'day', 'month', 'year'] as const;
-type Unit = typeof units[number];
+/**
+  JC: For reasons that I don't entirely understand, we get a build error
+  if we do
+  ```
+  const units = ["second", "minute", "hour", "day", "month", "year"] as const;
+  type Unit = typeof units[number];
+  ```
+  I'd prefer that as it's less redundant, but oh well
+*/
+type Unit = "second" | "minute" | "hour" | "day" | "month" | "year";
+const units: Unit[] = ['second', 'minute', 'hour', 'day', 'month', 'year'];
 
 function changeValue(unit: Unit, increment: boolean) {
   const limit = limits.value[unit].max;

--- a/src/components/DateTimePicker.vue
+++ b/src/components/DateTimePicker.vue
@@ -156,7 +156,7 @@
 
 
 <script setup lang="ts">
-import { ref, watch, computed } from 'vue';
+import { ref, watch, computed, type VNode } from 'vue';
 import TapToInput from './TapToInput.vue';
 import { DateTimePickerProps } from "../types";
 
@@ -168,7 +168,15 @@ const props = withDefaults(defineProps<DateTimePickerProps>(), {
 });
 
 const emit = defineEmits<{
+  /** Fired whenever the datetime value is change d*/
   (event: "update:modelValue", datetime: Date): void
+}>();
+
+defineSlots<{
+  default(): VNode[];
+  topMiddle(): VNode[];
+  centerMiddle(): VNode[];
+  bottomMiddle(): VNode[];
 }>();
 
 const year = ref(props.modelValue.getFullYear());

--- a/src/components/Gallery.vue
+++ b/src/components/Gallery.vue
@@ -9,7 +9,9 @@
     <slot
       name="closed"
       v-if="!open"
-      v-bind="props"
+      :places="places"
+      :selected-place="selectedPlace"
+      :selected-places="selectedPlaces"
     >
       <div
         class="default-activator blurred"
@@ -101,7 +103,7 @@ const emit = defineEmits<{
 }>();
 
 defineSlots<{
-  /** A slot allowing customization of what is shown when the gallery is closed. This slot has access to all of the component props. */
+  /** A slot allowing customization of what is shown when the gallery is closed. This slot has access to the component's list of places and selected place(s).*/
   closed(props: GalleryProps): VNode[];
 }>();
 

--- a/src/components/Gallery.vue
+++ b/src/components/Gallery.vue
@@ -9,6 +9,7 @@
     <slot
       name="closed"
       v-if="!open"
+      v-bind="props"
     >
       <div
         class="default-activator blurred"
@@ -66,7 +67,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, computed, watch, onBeforeMount, toRaw } from "vue";
+import { ref, reactive, computed, watch, onBeforeMount, toRaw, type VNode } from "vue";
 import { engineStore } from "@wwtelescope/engine-pinia";
 import { Folder, Imageset, Place } from "@wwtelescope/engine";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
@@ -91,9 +92,17 @@ const props = withDefaults(defineProps<GalleryProps>(), {
 });
 
 const emit = defineEmits<{
-  "select": [place: Place],
-  "deselect": [place: Place],
-  "listAllSelected": [places: Place[]],
+  /** Fired whenever an image is selected. The event value is the WWT `Place` associated with the image */
+  (event: "select", place: Place): void
+  /** Fired whenever an image is deselected. The event value is the WWT `Place` associated with the image */
+  (event: "deselect", place: Place): void
+  /** Fired whenever an image is selected. The event value is a list of WWT `Place`s associated with all selected images */
+  (event: "listAllSelected", places: Place[]): void
+}>();
+
+defineSlots<{
+  /** A slot allowing customization of what is shown when the gallery is closed. This slot has access to all of the component props. */
+  closed(props: GalleryProps): VNode[];
 }>();
 
 const store = engineStore();

--- a/src/components/IconButton.vue
+++ b/src/components/IconButton.vue
@@ -42,7 +42,7 @@
 
 
 <script setup lang="ts">
-import { computed, ref, useAttrs } from "vue";
+import { computed, ref, useAttrs, type VNode } from "vue";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { VIcon } from "vuetify/components/VIcon";
 import { VTooltip } from "vuetify/components/VTooltip";
@@ -68,8 +68,15 @@ const props = withDefaults(defineProps<IconButtonProps>(), {
 });
 
 const emit = defineEmits<{
-  "update:modelValue": [active: boolean],
-  "activate": [activate?: null]
+  /** Fired whenever the modelValue of the button changes. If no modelValue is assigned, this will not fire */
+  (event: "update:modelValue", active: boolean): void
+  /** Fired whenever the button is pressed. This allows receiving events even when a modelValue is not assigned. */
+  (event: "activate"): void
+}>();
+
+defineSlots<{
+  /** Allows configuration of the button content, which by default is simply the button icon */
+  button(): VNode[];
 }>();
 
 

--- a/src/components/LocationSearch.vue
+++ b/src/components/LocationSearch.vue
@@ -70,9 +70,12 @@ const props = withDefaults(defineProps<LocationSearchProps>(), {
 });
 
 const emit = defineEmits<{
-  (e: "error", message: string): void
-  (e: "set-location", feature: MapBoxFeature): void
-  (e: "update:modelValue", value: boolean): void
+  /** Fires when there is an error identifying a searched location. The event value is a message describing the error. */
+  (event: "error", message: string): void
+  /** Fires whenever the location changes. The event value is a `MapBoxFeature` describing the location. */
+  (event: "set-location", feature: MapBoxFeature): void
+  /** Fires whenever the search is opened or closed. The event value is a boolean that is true if the search is open. */
+  (event: "update:modelValue", value: boolean): void
 }>();
 
 const searchOpen = ref(props.modelValue || props.stayOpen);

--- a/src/components/LocationSelector.vue
+++ b/src/components/LocationSelector.vue
@@ -61,10 +61,12 @@ const props = withDefaults(defineProps<LocationSelectorProps>(), {
 });
 
 const emit = defineEmits<{
-  mapReady: [ready?: null],
-  error: [msg: string],
-  place: [place: PlaceDeg],
-  "update:modelValue": [location: LocationDeg],
+  /** Fires when the location selector map is ready for use */
+  (event: "mapReady"): void
+  /** Fires whenever there is an error getting the location for the selected position. The event value is a message describing the error. */
+  (event: "error", message: string): void
+  /** Fires whenever the selected location changes. The event value is an object containing the longitude and latitude of the location in degrees. */
+  (event: "update:modelValue", location: LocationDeg): void
 }>();
 
 const placeCircles = ref<L.CircleMarker[]>([]);

--- a/src/components/LocationSelector.vue
+++ b/src/components/LocationSelector.vue
@@ -65,6 +65,8 @@ const emit = defineEmits<{
   (event: "mapReady"): void
   /** Fires whenever there is an error getting the location for the selected position. The event value is a message describing the error. */
   (event: "error", message: string): void
+  /** Fires whenever a predefined place is selected. The event value is an object describing the selected place. */
+  (event: "place", place: PlaceDeg): void
   /** Fires whenever the selected location changes. The event value is an object containing the longitude and latitude of the location in degrees. */
   (event: "update:modelValue", location: LocationDeg): void
 }>();

--- a/src/components/ShareButton.vue
+++ b/src/components/ShareButton.vue
@@ -60,7 +60,8 @@ const props = withDefaults(defineProps<ShareButtonProps>(), {
 });
 
 const emit = defineEmits<{
-  "share": [activate?: null],
+  /** Fired whenever the share button is pressed. */
+  (event: "share"): void
 }>();
 
 function getURL() {

--- a/src/components/SpeedControl.vue
+++ b/src/components/SpeedControl.vue
@@ -235,11 +235,17 @@ const props = withDefaults(defineProps<SpeedControlProps>(), {
 const minSpeed = 1;
 
 const emit = defineEmits<{
+  /** Fired whenever the reset button is pressed .*/
   (event: "reset"): void
+  /** Fired whenever the reverse button is pressed. The event value is a boolean that is true if playback is now reversed. */
   (event: "update:reverse", reverse: boolean): void
+  /** Fired whenever the playback is started or paused. The event value is a boolean that is true if time is now playing. */
   (event: "update:modelValue", playing: boolean): void
+  /** Fired whenever the slowdown button is pressed. The event value is the new playback rate */
   (event: "slow-down", rate: number): void
+  /** Fired whenever the speed up button is pressed. The event value is the new playback rate. */
   (event: "speed-up", rate: number): void
+  /** Fired whenever the playback rate is changed. The event value is the new playback rate. */
   (event: "set-rate", rate: number): void
 }>();
 

--- a/src/components/WwtHud.vue
+++ b/src/components/WwtHud.vue
@@ -26,7 +26,7 @@
       </p>
       
       <!-- a default slot for whatever -->
-      <slot v-bind="props"></slot>
+      <slot :store="store"></slot>
       
     </div>
   </div>
@@ -56,7 +56,7 @@ const props = withDefaults(defineProps<WwtHUDProps>(), {
 });
 
 defineSlots<{
-  /** A slot for displaying extra WWT content below the default HUD content. This slot has access to all of the component props (including the WWT store). */ 
+  /** A slot for displaying extra WWT content below the default HUD content. This slot has access to the WWT store passed in via the component props. */ 
   default(props: WwtHUDProps): VNode[];
 }>();
 

--- a/src/components/WwtHud.vue
+++ b/src/components/WwtHud.vue
@@ -26,7 +26,7 @@
       </p>
       
       <!-- a default slot for whatever -->
-      <slot></slot>
+      <slot v-bind="props"></slot>
       
     </div>
   </div>
@@ -34,7 +34,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, type VNode } from "vue";
 import { Settings } from "@wwtelescope/engine";
 import { storeToRefs } from "pinia";
 
@@ -54,6 +54,11 @@ const props = withDefaults(defineProps<WwtHUDProps>(), {
   backgroundColor: "rgba(0, 0, 0, 0.5)",
   textShadow: "0 0 5px black",
 });
+
+defineSlots<{
+  /** A slot for displaying extra WWT content below the default HUD content. This slot has access to all of the component props (including the WWT store). */ 
+  default(props: WwtHUDProps): VNode[];
+}>();
 
 /*
 * I really don't care for passing the store as a prop,

--- a/src/stories/CreditLogos.stories.ts
+++ b/src/stories/CreditLogos.stories.ts
@@ -6,6 +6,7 @@ import { CreditLogos, CreditLogosProps } from "..";
 const meta: Meta<typeof CreditLogos> = {
   component: CreditLogos,
   tags: ["autodocs"],
+  title: "Vue Toolkit/Components/Credit Logos",
 };
 
 export default meta;

--- a/src/stories/DateTimePicker.stories.ts
+++ b/src/stories/DateTimePicker.stories.ts
@@ -39,5 +39,6 @@ export const Primary: Story = {
     debug: false,
     useAmPm: true,
     editableTime: true,
+    accentColor: "#f4ba3e",
   }
 };

--- a/src/stories/DateTimePicker.stories.ts
+++ b/src/stories/DateTimePicker.stories.ts
@@ -8,6 +8,7 @@ import { ref } from "vue";
 const meta: Meta<typeof DateTimePicker> = {
   component: DateTimePicker,
   tags: ["autodocs"],
+  title: "Vue Toolkit/Components/Datetime Picker",
 };
 
 export default meta;

--- a/src/stories/FundingAcknowledgement.stories.ts
+++ b/src/stories/FundingAcknowledgement.stories.ts
@@ -6,6 +6,7 @@ import { FundingAcknowledgement, FundingAcknowledgementProps } from "..";
 const meta: Meta<typeof FundingAcknowledgement> = {
   component: FundingAcknowledgement,
   tags: ["autodocs"],
+  title: "Vue Toolkit/Components/Funding Acknowledgement",
 };
 
 export default meta;

--- a/src/stories/Gallery.stories.ts
+++ b/src/stories/Gallery.stories.ts
@@ -7,6 +7,7 @@ import { WWTComponent } from "@wwtelescope/engine-pinia";
 const meta: Meta<typeof Gallery> = {
   component: Gallery,
   tags: ["autodocs"],
+  title: "Vue Toolkit/Components/Gallery",
 };
 
 export default meta;

--- a/src/stories/IconButton.stories.ts
+++ b/src/stories/IconButton.stories.ts
@@ -12,6 +12,7 @@ library.add(faBookOpen);
 const meta: Meta<typeof IconButton> = {
   component: IconButton,
   tags: ["autodocs"],
+  title: "Vue Toolkit/Components/Icon Button",
 };
 
 export default meta;

--- a/src/stories/LocationSearch.stories.ts
+++ b/src/stories/LocationSearch.stories.ts
@@ -9,6 +9,7 @@ import "./stories.css";
 const meta: Meta<typeof LocationSearch> = {
   component: LocationSearch,
   tags: ["autodocs"],
+  title: "Vue Toolkit/Components/Location Search",
 };
 
 export default meta;

--- a/src/stories/LocationSelector.stories.ts
+++ b/src/stories/LocationSelector.stories.ts
@@ -7,6 +7,7 @@ import { ref } from "vue";
 const meta: Meta<typeof LocationSelector> = {
   component: LocationSelector,
   tags: ["autodocs"],
+  title: "Vue Toolkit/Components/Location Selector",
 };
 
 export default meta;

--- a/src/stories/ShareButton.stories.ts
+++ b/src/stories/ShareButton.stories.ts
@@ -6,6 +6,7 @@ import { ShareButton, ShareButtonProps } from "..";
 const meta: Meta<typeof ShareButton> = {
   component: ShareButton,
   tags: ["autodocs"],
+  title: "Vue Toolkit/Components/Share Button",
 };
 
 export default meta;

--- a/src/stories/SpeedControl.stories.ts
+++ b/src/stories/SpeedControl.stories.ts
@@ -9,6 +9,7 @@ import "./stories.css";
 const meta: Meta<typeof SpeedControl> = {
   component: SpeedControl,
   tags: ["autodocs"],
+  title: "Vue Toolkit/Components/Speed Control",
 };
 
 export default meta;

--- a/src/stories/WwtHud.stories.ts
+++ b/src/stories/WwtHud.stories.ts
@@ -9,6 +9,7 @@ import "./stories.css";
 const meta: Meta<typeof WwtHud> = {
   component: WwtHud,
   tags: ["autodocs"],
+  title: "Vue Toolkit/Components/WWT HUD",
 };
 
 export default meta;


### PR DESCRIPTION
As the first piece of an effort to improve the toolkit documentation, this PR makes a few updates to our Storybook docs:

* Use the [`vue-component-meta`](https://www.npmjs.com/package/vue-component-meta) tool in the Storybook configuration to allow gathering slot and event data for each component
* Add docstrings for events and slots. Similar to what we do for the prop types, this is done by adding JSDoc-style comments to `defineEmits` and `defineSlots` inside the components.
* In anticipation of adding some non-component narrative documentation, this PR groups all of the stories under the "Vue Toolkit" group, and puts all of the components into a "Components" folder. This will ultimately allow for better navigation in the left-hand dropdown menu.
* MDX stories are no longer supported in Storybook 8, so remove the MDX pattern from the Storybook config

While this is mostly a documentation update, there are a few changes to the components themselves:
* Update and standardize the format of `defineEmits` across components
* Add `defineSlots` definitions to components that have slots
* Rename the slots for the `DateTimePicker` to not have hyphens. I didn't really want to do this, but Storybook (or Vue, not sure at which level the problem is at) doesn't seem to know how to do the sort of kebab/Pascal-case conversion that Vue often uses when setting up the docs. Thus, easier to just not need any conversion at all.