### PR TITLE
Add missing end tag in location selector story

### DIFF
--- a/src/stories/LocationSelector.stories.ts
+++ b/src/stories/LocationSelector.stories.ts
@@ -33,6 +33,7 @@ export const Primary: Story = {
           />
           <hr style="margin: 30px">
           <div style="width: 100%; text-align: center;">The last selected coordinates are latitude {{ location.latitudeDeg }}, longitude {{ location.longitudeDeg }}</div>
+        </div>
         `,
       setup() {
         return { args, location };


### PR DESCRIPTION
Currently the location selector story in the docs is broken because of a missing end tag. This PR adds it in.