### PR TITLE
Add watcher so that fullscreen composable works

### DIFF
--- a/src/composables/fullscreen.ts
+++ b/src/composables/fullscreen.ts
@@ -1,4 +1,4 @@
-import { ref, onMounted, onUnmounted, Ref } from "vue";
+import { ref, watch, onMounted, onUnmounted, Ref } from "vue";
 import screenfull from "screenfull";
 
 /**
@@ -20,6 +20,14 @@ export function useFullscreen(): Ref<boolean> {
   onUnmounted(() => {
     if (screenfull.isEnabled) {
       screenfull.off("change", update);
+    }
+  });
+
+  watch(fullscreenModeActive, (active: boolean) => {
+    if (active) {
+      screenfull.request();
+    } else {
+      screenfull.exit();
     }
   });
 


### PR DESCRIPTION
Currently the fullscreen composable doesn't actually work, because it's missing the piece where the screen responds to an update in the ref. This PR adds in the missing watcher.