### PR TITLE
add prop to hide advanced time controls

### DIFF
--- a/src/components/SpeedControl.vue
+++ b/src/components/SpeedControl.vue
@@ -94,7 +94,7 @@
       ></icon-button>
 
       <v-dialog
-        v-if="!useInline"
+        v-if="!useInline && !hideMoreControls"
         v-model="playbackVisible"
         :scrim="false"
         location="top"
@@ -230,6 +230,7 @@ const props = withDefaults(defineProps<SpeedControlProps>(), {
   rateDelta: 10,
   useInline: false,
   modelValue: false,
+  hideMoreControls: false,
 });
 
 const minSpeed = 1;

--- a/src/stories/SpeedControl.stories.ts
+++ b/src/stories/SpeedControl.stories.ts
@@ -45,5 +45,6 @@ export const Primary: Story = {
     showStatus: false,
     rateDelta: 10,
     modelValue: false,
+    hideMoreControls: false,
   }
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -317,6 +317,8 @@ export interface SpeedControlProps {
   showStatus?: boolean;
   /** The factor by which to adjust the WWT speed when speeding up or down */ 
   rateDelta?: number;
+  /** Whether or not to display the additional speed controls */
+  hideMoreControls?: boolean;
 }
 
 /** An async function taking an input string and returning a collection of MapBox Features */


### PR DESCRIPTION
This allows us to hide the advanced time controls for stories where they are not needed. The default is to display them.