### PR TITLE
Inject API key into Storybook build

### DIFF
--- a/.github/workflows/build-deploy-dev-docs.yml
+++ b/.github/workflows/build-deploy-dev-docs.yml
@@ -36,6 +36,7 @@ jobs:
         run: yarn build-storybook 
         env:
           VUE_APP_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+          VUE_APP_CDS_API_KEY: ${{ secrets.CDS_API_KEY }}
 
       - name: Rename docs folder to dev
         run: mv docs dev


### PR DESCRIPTION
This PR injects an API key into the Storybook build so that we can use it in stories if necessary. Note that this is a rather restricted API key that won't work for most endpoints.