### PR TITLE
Pass engine store into gallery as a prop

### DIFF
--- a/src/components/Gallery.vue
+++ b/src/components/Gallery.vue
@@ -107,7 +107,6 @@ defineSlots<{
   closed(props: GalleryProps): VNode[];
 }>();
 
-const store = engineStore();
 const open = ref(false);
 let places = reactive<Place[]>([]);
 const selectedPlace = ref<Place | null>(null);
@@ -123,7 +122,7 @@ const cssVars = computed(() => {
 });
 
 onBeforeMount(() => {
-  store.waitForReady().then(async () => {
+  props.store.waitForReady().then(async () => {
     places = await placesFromWtml(props.wtmlUrl);
   });
 });
@@ -148,7 +147,7 @@ function extractPlaces(folder: Folder): Place[] {
 }
 
 async function placesFromWtml(wtmlUrl: string): Promise<Place[]> {
-  return store.loadImageCollection({
+  return props.store.loadImageCollection({
     url: wtmlUrl,
     loadChildFolders: true
   }).then((folder) => extractPlaces(folder));

--- a/src/components/Gallery.vue
+++ b/src/components/Gallery.vue
@@ -149,7 +149,7 @@ async function placesFromWtml(wtmlUrl: string): Promise<Place[]> {
   return props.store.loadImageCollection({
     url: wtmlUrl,
     loadChildFolders: true
-  }).then((folder) => extractPlaces(folder));
+  }).then((folder: Folder) => extractPlaces(folder));
 }
 
 function selectPlace(place: Place) {

--- a/src/components/Gallery.vue
+++ b/src/components/Gallery.vue
@@ -70,7 +70,6 @@
 
 <script setup lang="ts">
 import { ref, reactive, computed, watch, onBeforeMount, toRaw, type VNode } from "vue";
-import { engineStore } from "@wwtelescope/engine-pinia";
 import { Folder, Imageset, Place } from "@wwtelescope/engine";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";

--- a/src/stories/Gallery.stories.ts
+++ b/src/stories/Gallery.stories.ts
@@ -2,7 +2,7 @@
 
 import { Meta, StoryObj } from "@storybook/vue3";
 import { Gallery, GalleryProps } from "..";
-import { WWTComponent } from "@wwtelescope/engine-pinia";
+import { engineStore, WWTComponent } from "@wwtelescope/engine-pinia";
 
 const meta: Meta<typeof Gallery> = {
   component: Gallery,
@@ -14,21 +14,24 @@ export default meta;
 type Story = StoryObj<typeof Gallery>;
 
 export const Primary: Story = {
-  render: (args: GalleryProps) => ({
-    components: { Gallery, WWTComponent },
-    template: `
-      <div>
-        <WWTComponent
-          :wwtNamespace="storybook"
-          style="display: none"
-        />
-        <Gallery v-bind="args" />
-      </div>
-    `,
-    setup() {
-      return { args };
-    },
-  }),
+  render: (args: GalleryProps) => {
+    const store = engineStore();
+    return {
+      components: { Gallery, WWTComponent },
+      template: `
+        <div>
+          <WWTComponent
+            wwtNamespace="storybook"
+            style="display: none"
+          />
+          <Gallery v-bind="args" :store="store" />
+        </div>
+      `,
+      setup() {
+        return { args, store };
+      },
+    };
+  },
   args: {
     wtmlUrl: "https://raw.githubusercontent.com/johnarban/wwt_interactives/main/images/m101/gallery.wtml",
     columns: 2,

--- a/src/stories/WwtHud.stories.ts
+++ b/src/stories/WwtHud.stories.ts
@@ -24,13 +24,13 @@ export const Primary: Story = {
         <div style="width: 1000px; height: 500px; position: relative;">
           <WwtHud v-bind="args" :store="store" />
           <WWTComponent
-            :wwtNamespace="storybook"
+            wwtNamespace="storybook"
           />
         </div>
       `,
       setup() {
         return { args, store };
-      }
+      },
     };
   },
   args: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,8 @@ export interface GalleryProps {
   previewIndex?: number;
   /** The text to show when the gallery is closed. Default is 'Image Gallery' */
   closedText?: string;
+  /** The WWT engine store to use for the HUD. Required */
+  store: WWTEngineStore;
 }
 
 /* Geolocation button */


### PR DESCRIPTION
This PR updates the Gallery component to take in the WWT engine store as a prop. Creating a new engine store was creating issues in a downstream story, so we can do this instead. This is the same approach used by the WWT HUD.

CC @johnarban - I didn't make the changes to the component itself that we made downstream (e.g. having the gallery control imagesets directly) in the interest of keeping this more flexible.