### PR TITLE
Add ARIA label prop for icon button

### DIFF
--- a/src/components/IconButton.vue
+++ b/src/components/IconButton.vue
@@ -22,6 +22,7 @@
         tabindex="0"
         :aria-disabled="disabled"
         :aria-label="ariaLabel"
+        role="button"
       >
         <slot name="button">
           <font-awesome-icon

--- a/src/components/IconButton.vue
+++ b/src/components/IconButton.vue
@@ -22,6 +22,7 @@
         tabindex="0"
         :aria-disabled="disabled"
         :aria-label="ariaLabel"
+        :aria-pressed="modelValue != null ? (modelValue ? 'true' : 'false') : null"
         role="button"
       >
         <slot name="button">

--- a/src/components/IconButton.vue
+++ b/src/components/IconButton.vue
@@ -21,6 +21,7 @@
         :style="cssVars"
         tabindex="0"
         :aria-disabled="disabled"
+        :aria-label="ariaLabel"
       >
         <slot name="button">
           <font-awesome-icon
@@ -67,7 +68,6 @@ const props = withDefaults(defineProps<IconButtonProps>(), {
   showTooltip: true,
   disabled: false,
 });
-console.log(props);
 
 const emit = defineEmits<{
   /** Fired whenever the modelValue of the button changes. If no modelValue is assigned, this will not fire */

--- a/src/stories/IconButton.stories.ts
+++ b/src/stories/IconButton.stories.ts
@@ -36,6 +36,7 @@ export const Primary: Story = {
   args: {
     modelValue: false,
     icon: "book-open",
+    ariaLabel: "Information",
     color: "white",
     focusColor: "red",
     activeColor: "green",

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,6 +134,8 @@ export interface IconButtonProps {
   modelValue?: boolean;
   /** The name of the FontAwesome or MDI icon to use. MDI icons should be specified with their `mdi-` prefix */
   icon: string;
+  /** ARIA label for the button */
+  ariaLabel: string;
   /** The primary color of the button. Sets the icon and border colors. Default is white */
   color?: string;
   /** The color of the button when focused. Default is white */


### PR DESCRIPTION
This PR resolves #103. I also added `role="button"` to the icon button component, as well as an `aria-pressed` attribute when the button has a v-model and can be "active".

The easiest way to test this is probably to open up the Storybook story and examine the rendered component there. That story now also has a field where you can change the ARIA label prop.