### PR TITLE
Add story for geolocation button

### DIFF
--- a/src/stories/GeolocationButton.stories.ts
+++ b/src/stories/GeolocationButton.stories.ts
@@ -20,6 +20,9 @@ export const Primary: Story = {
 
     const geolocation = ref<PositionCoords | null>(null);
     const permission = ref<string | null>(null);
+    function showError(error: Error) {
+      alert(error.message);
+    }
     return {
       components: { GeolocationButton },
       template: `
@@ -29,7 +32,7 @@ export const Primary: Story = {
               v-bind="args"
               @permission="perm => permission = perm"
               @geolocation="location => geolocation = location"
-              @error="error => alert(error)"
+              @error="showError"
             />
           </div>
           <div v-if="permission != null">Permission: {{ permission }}</div>
@@ -42,7 +45,7 @@ export const Primary: Story = {
         </div>
       `,
       setup() {
-        return { args, geolocation, permission };
+        return { args, geolocation, permission, showError };
       }
     };
   },

--- a/src/stories/GeolocationButton.stories.ts
+++ b/src/stories/GeolocationButton.stories.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
 import { Meta, StoryObj } from "@storybook/vue3";
-import { GeolocationButton, GeolocationButtonProps } from "..";
+import { ref } from "vue";
+import { GeolocationButton, GeolocationButtonProps, PositionCoords } from "..";
 
 import "./stories.css";
 
@@ -15,13 +16,36 @@ export default meta;
 type Story = StoryObj<typeof GeolocationButton>;
 
 export const Primary: Story = {
-  render: (args: GeolocationButtonProps) => ({
-    components: { GeolocationButton },
-    template: `<GeolocationButton v-bind="args" />`,
-    setup() {
-      return { args };
-    }
-  }),
+  render: (args: GeolocationButtonProps) => {
+
+    const geolocation = ref<PositionCoords | null>(null);
+    const permission = ref<string | null>(null);
+    return {
+      components: { GeolocationButton },
+      template: `
+        <div style="width: 900px; height: 500px; display: flex; flex-direction: column; gap: 10px;">
+          <div>
+            <GeolocationButton
+              v-bind="args"
+              @permission="perm => permission = perm"
+              @geolocation="location => geolocation = location"
+              @error="error => alert(error)"
+            />
+          </div>
+          <div v-if="permission != null">Permission: {{ permission }}</div>
+          <div v-if="geolocation != null">
+            <p><strong>Location</strong></p>
+            <p>Longitude: {{ geolocation.longitude }}</p>
+            <p>Latitude: {{ geolocation.latitude }}</p>
+            <p>Accuracy: {{ geolocation.accuracy }}</p>
+          </div>
+        </div>
+      `,
+      setup() {
+        return { args, geolocation, permission };
+      }
+    };
+  },
   args: {
     color: "black",
     size: "medium",

--- a/src/stories/GeolocationButton.stories.ts
+++ b/src/stories/GeolocationButton.stories.ts
@@ -1,0 +1,27 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+import { Meta, StoryObj } from "@storybook/vue3";
+import { GeolocationButton, GeolocationButtonProps } from "..";
+
+import "./stories.css";
+
+const meta: Meta<typeof GeolocationButton> = {
+  component: GeolocationButton,
+  tags: ["autodocs"],
+  title: "Vue Toolkit/Components/Geolocation Button",
+};
+
+export default meta;
+type Story = StoryObj<typeof GeolocationButton>;
+
+export const Primary: Story = {
+  render: (args: GeolocationButtonProps) => ({
+    components: { GeolocationButton },
+    template: `<GeolocationButton v-bind="args" />`,
+    setup() {
+      return { args };
+    }
+  }),
+  args: {
+  }
+};

--- a/src/stories/GeolocationButton.stories.ts
+++ b/src/stories/GeolocationButton.stories.ts
@@ -23,5 +23,21 @@ export const Primary: Story = {
     }
   }),
   args: {
+    color: "black",
+    size: "medium",
+    density: "comfortable",
+    elevation: "2",
+    hideButton: false,
+    showTextLabel: false,
+    showCoords: false,
+    showTextProgress: false,
+    showProgressCircle: true,
+    useTextButton: false,
+    progressCircleSize: 12,
+    label: "My Location",
+    id: "geolocation-button",
+    trueIcon: "mdi-crosshairs-gps",
+    falseIcon: "mdi-crosshairs",
+    showPermissions: false,
   }
 };


### PR DESCRIPTION
This PR resolves #105 by adding a story for the geolocation button. The story layout is simple for now, but it does show the permission level, the latitude/longitude/accuracy of the most recent location (if one has been found), and any errors pop up as browser alerts.